### PR TITLE
fix(protocol): fix visual issue with add button positioning

### DIFF
--- a/src/components/AddDataFields/AddTextField.tsx
+++ b/src/components/AddDataFields/AddTextField.tsx
@@ -39,11 +39,13 @@ export default function AddTextField({ onAddText, text, label }: IAddTextFieldPr
 
   return (
     <FormControl sx={formcontrol} mt="3rem">
+      <FormLabel>{label}</FormLabel>
       <Box display="flex" justifyContent="space-between" alignItems="center">
-        <FormLabel>{label}</FormLabel>
-        <EventButton event={handleAddText} text="ADD" w={"2%"} />
+        <TextAreaInput value={inputValue} label="" placeholder={text} onChange={handleInputChange}></TextAreaInput>
       </Box>
-      <TextAreaInput value={inputValue} label="" placeholder={text} onChange={handleInputChange}></TextAreaInput>
+      <Box display="flex" justifyContent="center" mt={4}>
+        <EventButton event={handleAddText} text="ADD" />
+      </Box>
     </FormControl>
   );
 }

--- a/src/components/Tables/ArticlesTable/Expanded.tsx
+++ b/src/components/Tables/ArticlesTable/Expanded.tsx
@@ -231,7 +231,7 @@ export default function Expanded({
                       >
                         {({ ref, isResizing }) => (
                           <Box
-                            ref={ref} 
+                            ref={ref as React.LegacyRef<HTMLDivElement>} 
                             position="relative"
                             h="100%"
                             w="100%" 


### PR DESCRIPTION
Adjusted the positioning of the "Add" button in the Protocol step to align with the current system layout.

The button was visually misaligned compared to the expected design, creating inconsistency in the user interface.

Now the button appears properly aligned within the section, following design specifications.

Before:

<img width="1201" height="289" alt="image" src="https://github.com/user-attachments/assets/2398bcad-9ea7-4264-a211-407fcd80d0ab" />

After:

<img width="1217" height="349" alt="image" src="https://github.com/user-attachments/assets/219e465d-d143-46f4-bd83-02301a7365f2" />

