### PR TITLE
fix(protocol): resolve tab focus issue on navigation buttons

### DIFF
--- a/src/components/Buttons/NavButton.tsx
+++ b/src/components/Buttons/NavButton.tsx
@@ -39,32 +39,27 @@ export default function NavButton({ text, path = '', variant = "default", event 
   };
 
   return (
-    <Link to={path}> 
-    
-      <Button 
-        ml='2rem'
-        onClick={handleClick}
-        bgColor={bgColor} 
-        color={color}
-        borderRadius={borderRadius}
-        _hover={{ 
-          bgColor: hoverBgColor,
-          color: hoverColor,
-          boxShadow: "0 6px 8px rgba(0, 0, 0, 0.15)" 
-
-        }}
-        {...buttonProps}
-        transition="all 0.3s ease" 
-        outline="none" 
-        _focus={{
-          boxShadow: "0 0 0 3px rgba(66, 153, 225, 0.6)", 
-        }}
-        
-        
-        >
-          {text}
-      </Button> 
-
-    </Link>
+    <Button 
+      as={path ? Link : undefined}
+      to={path || undefined}
+      ml='2rem'
+      onClick={handleClick}
+      bgColor={bgColor} 
+      color={color}
+      borderRadius={borderRadius}
+      _hover={{ 
+        bgColor: hoverBgColor,
+        color: hoverColor,
+        boxShadow: "0 6px 8px rgba(0, 0, 0, 0.15)" 
+      }}
+      {...buttonProps}
+      transition="all 0.3s ease" 
+      outline="none" 
+      _focus={{
+        boxShadow: "0 0 0 3px rgba(66, 153, 225, 0.6)", 
+      }}
+    >
+      {text}
+    </Button> 
   );
 }

--- a/src/components/Tables/ArticlesTable/Expanded.tsx
+++ b/src/components/Tables/ArticlesTable/Expanded.tsx
@@ -231,7 +231,7 @@ export default function Expanded({
                       >
                         {({ ref, isResizing }) => (
                           <Box
-                            ref={ref} 
+                            ref={ref as React.LegacyRef<HTMLDivElement>} 
                             position="relative"
                             h="100%"
                             w="100%" 


### PR DESCRIPTION
Fixed an accessibility issue where the "Back" and "Next" navigation buttons in the Protocol step could not be properly focused using the Tab key.

The buttons were wrapped in a <Link> element that contained a <Button> component, resulting in invalid HTML and broken keyboard navigation (focus skipping the buttons).

Now, users can navigate to the "Back" and "Next" buttons using the Tab key, improving accessibility and aligning the behavior with expected UI standards.

Before:

<img width="240" height="75" alt="image" src="https://github.com/user-attachments/assets/98b8c1bc-207e-4b49-85e2-63913de931d0" />

After:

<img width="198" height="76" alt="image" src="https://github.com/user-attachments/assets/725fbf43-c864-4410-83ea-54c752f8a505" />
