### PR TITLE
feat(ui): improve title responsiveness by using responsive array font sizes

### DIFF
--- a/src/components/Modals/StudyModal/ArticlePreview.tsx
+++ b/src/components/Modals/StudyModal/ArticlePreview.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Text, useBreakpointValue } from "@chakra-ui/react";
+import { Button, Flex, Text, } from "@chakra-ui/react";
 
 import { ArticlePreviewProps } from "./StudyData";
 
@@ -63,13 +63,6 @@ export default function ArticlePreview({ studyData }: ArticlePreviewProps) {
       color: "green",
     },
   };
-
-  const responsiveFontSize = useBreakpointValue({
-    base: "md",
-    md: "lg",
-    lg: "2xl",
-    xl: "3xl",
-  });
 
   const selectionStatus = statusIconMap[studyData.selectionStatus];
   const priorityLevel = priorityIconMap[studyData.readingPriority];
@@ -179,7 +172,7 @@ export default function ArticlePreview({ studyData }: ArticlePreviewProps) {
             </Text>
           </Text>
           <Text
-            fontSize={"20px"}
+            fontSize={"16px"}
             align={"right"}
             as="i"
             fontWeight={"Bold"}
@@ -190,7 +183,7 @@ export default function ArticlePreview({ studyData }: ArticlePreviewProps) {
         </Flex>
 
         <Text
-          fontSize={responsiveFontSize}
+          fontSize={["xl", "2xl", "3xl", "4xl"]}
           fontWeight={"bold"}
           fontFamily={"Boboni"}
           lineHeight={"2.3rem"}

--- a/src/components/Modals/StudyModal/ArticlePreview.tsx
+++ b/src/components/Modals/StudyModal/ArticlePreview.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Text } from "@chakra-ui/react";
+import { Button, Flex, Text, useBreakpointValue } from "@chakra-ui/react";
 
 import { ArticlePreviewProps } from "./StudyData";
 
@@ -63,6 +63,13 @@ export default function ArticlePreview({ studyData }: ArticlePreviewProps) {
       color: "green",
     },
   };
+
+  const responsiveFontSize = useBreakpointValue({
+    base: "md",
+    md: "lg",
+    lg: "2xl",
+    xl: "3xl",
+  });
 
   const selectionStatus = statusIconMap[studyData.selectionStatus];
   const priorityLevel = priorityIconMap[studyData.readingPriority];
@@ -183,11 +190,13 @@ export default function ArticlePreview({ studyData }: ArticlePreviewProps) {
         </Flex>
 
         <Text
-          fontSize={"35"}
+          fontSize={responsiveFontSize}
           fontWeight={"bold"}
           fontFamily={"Boboni"}
-          lineHeight="2.3rem"
+          lineHeight={"2.3rem"}
           align={"center"}
+          whiteSpace={"normal"}
+          wordBreak={"break-word"}
         >
           {studyData.title}
         </Text>


### PR DESCRIPTION
### ✅ Descrição

Este PR melhora a responsividade do título da página de visualização de artigo ao substituir o valor fixo de fontSize por um array responsivo suportado pelo Chakra UI.

Essa mudança garante que o tamanho do título se adapte corretamente a diferentes tamanhos de tela, oferecendo melhor legibilidade e impacto visual, especialmente em resoluções maiores.

### Antes

<img width="536" height="670" alt="image" src="https://github.com/user-attachments/assets/2ce354ef-4820-417b-b289-028b2b797f4b" />


### Depois

<img width="544" height="552" alt="image" src="https://github.com/user-attachments/assets/e90a010b-9d5f-40da-b9ac-a33a561cdad3" />
