### PR TITLE
feat(article-preview): improve title display to wrap text and adapt to different screen sizes

### DIFF
--- a/src/features/review/shared/components/common/tables/ArticlePreview/index.tsx
+++ b/src/features/review/shared/components/common/tables/ArticlePreview/index.tsx
@@ -172,7 +172,7 @@ export default function ArticlePreview({ studyData }: ArticlePreviewProps) {
             </Text>
           </Text>
           <Text
-            fontSize={"20px"}
+            fontSize={"16px"}
             align={"right"}
             as="i"
             fontWeight={"Bold"}
@@ -183,11 +183,14 @@ export default function ArticlePreview({ studyData }: ArticlePreviewProps) {
         </Flex>
 
         <Text
-          fontSize={"35"}
+          fontSize={["xl", "2xl", "3xl", "4xl"]}
           fontWeight={"bold"}
           fontFamily={"Boboni"}
-          lineHeight="2.3rem"
+          lineHeight={"2.3rem"}
           align={"center"}
+          whiteSpace={"normal"}
+          wordBreak={"break-word"}
+          maxWidth={"100%"}
         >
           {studyData.title}
         </Text>


### PR DESCRIPTION
## Summary
This PR updates the article preview component to display the full title without truncation. 
The styling now ensures that titles wrap naturally and adapt to various screen sizes, improving readability.

## Changes
- Removed ellipsis from the article preview title.
- Added responsive font sizes and line-height adjustments.
- Enabled word wrapping and ensured max width within the container.
- Maintained overall visual consistency across devices.

## Before

<img width="562" height="695" alt="image" src="https://github.com/user-attachments/assets/501f5452-1b2f-4093-aec7-15bdb0e22c63" />


## After

<img width="559" height="552" alt="image" src="https://github.com/user-attachments/assets/9424b3f8-bdd6-4f0b-9ec5-55ade3856749" />
