### PR TITLE
feat(ui): responsive min-height for articles table and aligned "View" button width

### DIFF
--- a/src/features/review/shared/components/common/menu/ColumnVisibilityMenu/index.tsx
+++ b/src/features/review/shared/components/common/menu/ColumnVisibilityMenu/index.tsx
@@ -63,10 +63,7 @@ export default function ColumnVisibilityMenu({
   });
 
   return (
-    <div
-      style={{ position: "relative", display: "inline-block" }}
-      ref={dropdownMenu}
-    >
+    <div className={styles["dropdown-wrapper"]} ref={dropdownMenu}>
       <button onClick={handleMenuState} className={styles["dropdown-toggle"]}>
         <div className={styles["dropdown-toggle-content"]}>
           <CgOptions />

--- a/src/features/review/shared/components/common/menu/ColumnVisibilityMenu/styles.module.css
+++ b/src/features/review/shared/components/common/menu/ColumnVisibilityMenu/styles.module.css
@@ -1,4 +1,11 @@
+.dropdown-wrapper {
+  display: inline-block;
+  min-width: 120px;
+  position: relative;
+}
+
 .dropdown-toggle {
+  width: 100%;
   padding: 0.5rem 1rem;
   background: #fff;
   color: #263c56;
@@ -14,7 +21,7 @@
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  gap: 1rem;
+  gap: 1.2rem;
 }
 
 .dropdown-toggle:hover {
@@ -22,6 +29,7 @@
 }
 
 .dropdown-container {
+  width: 100%;
   position: absolute;
   top: 100%;
   right: 0;

--- a/src/features/review/shared/components/common/tables/ArticlesTable/subcomponents/Expanded/index.tsx
+++ b/src/features/review/shared/components/common/tables/ArticlesTable/subcomponents/Expanded/index.tsx
@@ -228,6 +228,15 @@ export default function Expanded({
     <Box w="100%" maxH="82.5vh">
       <TableContainer
         w="100%"
+        minH={
+          layout == "horizontal" || layout == "horizontal-invert"
+            ? "12rem"
+            : {
+                base: "calc(100vh - 18rem)",
+                md: "calc(100vh - 20rem)",
+                lg: "calc(100vh - 25rem)",
+              }
+        }
         maxH={
           layout == "horizontal" || layout == "horizontal-invert"
             ? "15rem"


### PR DESCRIPTION
## Description

This PR introduces UI improvements aimed at enhancing visual consistency and usability:

### 1. Responsive minimum height for the articles table body
- Sets a fixed minimum height that adapts to different screen sizes.
- Maintains visual consistency even when the table has few rows.
- Reduces layout shifts when switching between different datasets.

### 2. Aligned "View" button and dropdown widths
- Ensures both button and dropdown have the same horizontal width.
- Reduced inner padding for a more compact appearance.
- Improves alignment and avoids excessive horizontal spacing.

### Before

<img width="1817" height="762" alt="image" src="https://github.com/user-attachments/assets/e2b85689-fdbf-4546-a29e-0418115de230" />
<img width="135" height="291" alt="image" src="https://github.com/user-attachments/assets/a5711a92-ab98-4bfe-bca7-6b3ec870763d" />

### After

<img width="1815" height="767" alt="image" src="https://github.com/user-attachments/assets/66ad2f83-5293-47ce-8ba3-7ae6044be7ff" />
<img width="136" height="297" alt="image" src="https://github.com/user-attachments/assets/7beb50d2-e412-4575-ab2f-350e6f35bd19" />

