### PR TITLE
feat(ui): apply capitalization formatting to selection components

### DIFF
--- a/src/features/review/execution-extraction/pages/Extraction/index.tsx
+++ b/src/features/review/execution-extraction/pages/Extraction/index.tsx
@@ -19,6 +19,7 @@ import LayoutFactory from "../../../shared/components/structure/LayoutFactory";
 import ButtonsForMultipleSelection from "../../../shared/components/common/buttons/ButtonsForMultipleSelection";
 import SelectLayout from "../../../shared/components/structure/LayoutButton";
 import ColumnVisibilityMenu from "@features/review/shared/components/common/menu/ColumnVisibilityMenu";
+import { capitalize } from "../../../../shared/utils/helpers/formatters/CapitalizeText";
 
 // Styles
 import { inputconteiner } from "../../../shared/styles/executionStyles";
@@ -114,7 +115,9 @@ export default function Extraction() {
                 toggleColumnVisibility={toggleColumnVisibility}
               />
               <SelectInput
-                names={["INCLUDED", "DUPLICATED", "EXCLUDED", "UNCLASSIFIED"]}
+                names={[
+                  capitalize("included"), capitalize("duplicated"), capitalize("excluded"), capitalize("unclassified"),
+                ]}
                 values={["INCLUDED", "DUPLICATED", "EXCLUDED", "UNCLASSIFIED"]}
                 onSelect={(value) => handleSelectChange(value)}
                 selectedValue={selectedStatus}

--- a/src/features/review/execution-selection/pages/Selection/index.tsx
+++ b/src/features/review/execution-selection/pages/Selection/index.tsx
@@ -19,6 +19,7 @@ import LayoutFactory from "../../../shared/components/structure/LayoutFactory";
 import ButtonsForMultipleSelection from "../../../shared/components/common/buttons/ButtonsForMultipleSelection";
 import SelectLayout from "../../../shared/components/structure/LayoutButton";
 import ColumnVisibilityMenu from "@features/review/shared/components/common/menu/ColumnVisibilityMenu";
+import { capitalize } from "../../../../shared/utils/helpers/formatters/CapitalizeText";
 
 // Styles
 import { inputconteiner } from "../../../shared/styles/executionStyles";
@@ -114,7 +115,9 @@ export default function Selection() {
                 toggleColumnVisibility={toggleColumnVisibility}
               />
               <SelectInput
-                names={["INCLUDED", "DUPLICATED", "EXCLUDED", "UNCLASSIFIED"]}
+                names={[
+                  capitalize("included"), capitalize("duplicated"), capitalize("excluded"), capitalize("unclassified"),
+                ]}
                 values={["INCLUDED", "DUPLICATED", "EXCLUDED", "UNCLASSIFIED"]}
                 onSelect={(value) => handleSelectChange(value)}
                 selectedValue={selectedStatus}

--- a/src/features/review/planning-protocol/components/common/inputs/text/AddTextField/index.tsx
+++ b/src/features/review/planning-protocol/components/common/inputs/text/AddTextField/index.tsx
@@ -49,7 +49,7 @@ export default function AddTextField({
         placeholder={text}
         onChange={handleInputChange}
       />
-      <EventButton event={handleAddText} text="ADD" w={"2%"} />
+      <EventButton event={handleAddText} text={capitalize("add")} w={"2%"} />
     </FormControl>
   );
 }

--- a/src/features/review/planning-protocol/pages/StepThree/subcomponents/inputs/labeledScale/AddLabeledScaleField.tsx
+++ b/src/features/review/planning-protocol/pages/StepThree/subcomponents/inputs/labeledScale/AddLabeledScaleField.tsx
@@ -14,6 +14,7 @@ import { useState } from "react";
 import useToaster from "@components/feedback/Toaster";
 import TextAreaInput from "@components/common/inputs/InputTextArea";
 import { formcontrol } from "@features/review/planning-protocol/components/common/inputs/text/AddTextField/styles";
+import { capitalize } from "@features/shared/utils/helpers/formatters/CapitalizeText";
 
 interface IAddTextFieldProps {
   onAddText: (newKeyword: { label: string; value: number }) => void;
@@ -70,7 +71,7 @@ export default function AddLabeledListField({
         </NumberInputStepper>
       </NumberInput>
 
-      <EventButton event={handleAddText} text="ADD" mt={2} w={"10%"} />
+      <EventButton event={handleAddText} text={capitalize("add")} mt={2} w={"10%"} />
     </FormControl>
   );
 }

--- a/src/features/review/planning-protocol/pages/StepThree/subcomponents/inputs/pickList/AddPickListField.tsx
+++ b/src/features/review/planning-protocol/pages/StepThree/subcomponents/inputs/pickList/AddPickListField.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { formcontrol } from "@features/review/planning-protocol/components/common/inputs/text/AddTextField/styles";
 import TextAreaInput from "@components/common/inputs/InputTextArea";
 import useToaster from "@components/feedback/Toaster";
+import { capitalize } from "@features/shared/utils/helpers/formatters/CapitalizeText";
 
 interface IAddTextFieldProps {
   onAddText: (newKeyword: string) => void;
@@ -43,7 +44,7 @@ export default function AddPickListField({
         placeholder={text}
         onChange={handleInputChange}
       ></TextAreaInput>
-      <EventButton event={handleAddText} text="ADD" mt={2} w={"10%"} />
+      <EventButton event={handleAddText} text={capitalize("add")} mt={2} w={"10%"} />
     </FormControl>
   );
 }

--- a/src/features/review/planning-protocol/pages/StepTwo/index.tsx
+++ b/src/features/review/planning-protocol/pages/StepTwo/index.tsx
@@ -9,6 +9,7 @@ import TextAreaInput from "../../../../../components/common/inputs/InputTextArea
 import AddTextTable from "../../components/common/inputs/text/AddTextTable";
 import AddSelectionTable from "../../components/common/inputs/selection/AddSelectionTable";
 import FlexLayout from "../../../../../components/structure/Flex/Flex";
+import { capitalize } from "../../../../shared/utils/helpers/formatters/CapitalizeText";
 
 // Service
 import useCreateProtocol from "../../services/useCreateProtocol";
@@ -71,7 +72,9 @@ export default function ProtocolPartTwo2() {
 
           <AddSelectionTable
             label="Languages"
-            options={["ENGLISH", "PORTUGUESE", "FRENCH", "SPANISH", "GERMAN"]}
+            options={[
+              capitalize("english"), capitalize("portuguese"), capitalize("french"), capitalize("spanish"), capitalize("german")
+            ]}
             placeholder={"Select language"}
             typeField="select"
           />


### PR DESCRIPTION
## Description

- Adjusted all selection components (SelectInput, EventButton, language dropdowns, etc.) to use capitalization for displaying values.
- Kept uppercase formatting only for internal values/enums (backend and integrations).
- Improves readability and visual consistency of the interface, following the design system.

<img width="332" height="203" alt="image" src="https://github.com/user-attachments/assets/7481afef-6305-46c0-afd8-1d298d3ed784" />