### PR TITLE
feat(selection, extraction): show article counts in status dropdowns

### DIFF
--- a/src/features/review/execution-extraction/pages/Extraction/index.tsx
+++ b/src/features/review/execution-extraction/pages/Extraction/index.tsx
@@ -45,9 +45,9 @@ export default function Extraction() {
   const isLoading = selectionContext?.isLoading ?? false;
 
   const allArticles: ArticleInterface[] = useMemo(() => {
-    return safeArticles
-      .filter((art): art is ArticleInterface => "studyReviewId" in art)
-      .filter((art) => art.selectionStatus === "INCLUDED");
+    return safeArticles.filter(
+      (art): art is ArticleInterface => "studyReviewId" in art
+    );
   }, [safeArticles]);
 
   const startFilteredArticles = useFilterReviewArticles(
@@ -66,6 +66,31 @@ export default function Extraction() {
     }
     return startFilteredArticles;
   }, [showSelected, startFilteredArticles, safeSelectedArticles]);
+
+  const statusCounts = useMemo(() => {
+    const counts: Record<string, number> = {
+      INCLUDED: 0,
+      DUPLICATED: 0,
+      EXCLUDED: 0,
+      UNCLASSIFIED: 0,
+    };
+
+    allArticles.forEach((article) => {
+      const status = article.extractionStatus as keyof typeof counts;
+      if (status && counts[status] !== undefined) {
+        counts[status] += 1;
+      }
+    });
+
+    return counts;
+  }, [allArticles]);
+
+  const statusOptions = [
+    { value: "INCLUDED", label: `Included (${statusCounts.INCLUDED})` },
+    { value: "DUPLICATED", label: `Duplicated (${statusCounts.DUPLICATED})` },
+    { value: "EXCLUDED", label: `Excluded (${statusCounts.EXCLUDED})` },
+    { value: "UNCLASSIFIED", label: `Unclassified (${statusCounts.UNCLASSIFIED})` },
+  ];
 
   return (
     <FlexLayout defaultOpen={1} navigationType="Accordion">
@@ -114,8 +139,8 @@ export default function Extraction() {
                 toggleColumnVisibility={toggleColumnVisibility}
               />
               <SelectInput
-                names={["INCLUDED", "DUPLICATED", "EXCLUDED", "UNCLASSIFIED"]}
-                values={["INCLUDED", "DUPLICATED", "EXCLUDED", "UNCLASSIFIED"]}
+                names={statusOptions.map((opt) => opt.label)}
+                values={statusOptions.map((opt) => opt.value)}
                 onSelect={(value) => handleSelectChange(value)}
                 selectedValue={selectedStatus}
                 page={"extraction"}

--- a/src/features/review/execution-selection/pages/Selection/index.tsx
+++ b/src/features/review/execution-selection/pages/Selection/index.tsx
@@ -67,6 +67,31 @@ export default function Selection() {
     return startFilteredArticles;
   }, [showSelected, startFilteredArticles, safeSelectedArticles]);
 
+  const statusCounts = useMemo(() => {
+    const counts: Record<string, number> = {
+      INCLUDED: 0,
+      DUPLICATED: 0,
+      EXCLUDED: 0,
+      UNCLASSIFIED: 0,
+    };
+
+    allArticles.forEach((article) => {
+      const status = article.selectionStatus as keyof typeof counts;
+      if (status && counts[status] !== undefined) {
+        counts[status] += 1;
+      }
+    });
+
+    return counts;
+  }, [allArticles]);
+
+  const statusOptions = [
+    { value: "INCLUDED", label: `Included (${statusCounts.INCLUDED})` },
+    { value: "DUPLICATED", label: `Duplicated (${statusCounts.DUPLICATED})` },
+    { value: "EXCLUDED", label: `Excluded (${statusCounts.EXCLUDED})` },
+    { value: "UNCLASSIFIED", label: `Unclassified (${statusCounts.UNCLASSIFIED})` },
+  ];
+
   return (
     <FlexLayout defaultOpen={1} navigationType="Accordion">
       <Box w="98%" m="1rem" h="fit-content">
@@ -114,8 +139,8 @@ export default function Selection() {
                 toggleColumnVisibility={toggleColumnVisibility}
               />
               <SelectInput
-                names={["INCLUDED", "DUPLICATED", "EXCLUDED", "UNCLASSIFIED"]}
-                values={["INCLUDED", "DUPLICATED", "EXCLUDED", "UNCLASSIFIED"]}
+                names={statusOptions.map((opt) => opt.label)}
+                values={statusOptions.map((opt) => opt.value)}
                 onSelect={(value) => handleSelectChange(value)}
                 selectedValue={selectedStatus}
                 page={"selection"}


### PR DESCRIPTION
## 📌 Descrição

- Adiciona a contagem de artigos em cada opção dos dropdowns de Selection status e Extraction status.

## 🔄 Alterações

- Contagem dinâmica de artigos por status.
- Atualização dos labels dos dropdowns em Selection e Extraction.

## ✅ Resultado

### Dropdowns exibem, por exemplo:
- Included (10)
- Duplicated (2)
- Excluded (5)
- Unclassified (8)