### PR TITLE
feat(ui): refactor Selection and Extraction components and unify StatusSelect

### DIFF
--- a/src/features/review/execution-extraction/pages/Extraction/index.tsx
+++ b/src/features/review/execution-extraction/pages/Extraction/index.tsx
@@ -9,33 +9,31 @@ import StudySelectionContext from "@features/review/shared/context/StudiesSelect
 import useInputState from "@features/review/shared/hooks/useInputState";
 import useLayoutPage from "../../../shared/hooks/useLayoutPage";
 import { useFilterReviewArticles } from "../../../shared/hooks/useFilterReviewArticles";
+import useVisibiltyColumns from "@features/review/shared/hooks/useVisibilityColumns";
 
 // Components
 import Header from "../../../../../components/structure/Header/Header";
 import FlexLayout from "../../../../../components/structure/Flex/Flex";
 import InputText from "../../../../../components/common/inputs/InputText";
-import SelectInput from "../../../../../components/common/inputs/SelectInput";
 import LayoutFactory from "../../../shared/components/structure/LayoutFactory";
-import ButtonsForMultipleSelection from "../../../shared/components/common/buttons/ButtonsForMultipleSelection";
 import SelectLayout from "../../../shared/components/structure/LayoutButton";
 import ColumnVisibilityMenu from "@features/review/shared/components/common/menu/ColumnVisibilityMenu";
+import StatusSelect from "@features/review/shared/components/common/inputs/StatusSelect";
+import ButtonsForMultipleSelection from "@features/review/shared/components/common/buttons/ButtonsForMultipleSelection";
 
 // Styles
 import { inputconteiner } from "../../../shared/styles/executionStyles";
 
 // Types
 import type ArticleInterface from "../../../shared/types/ArticleInterface";
-import useVisibiltyColumns from "@features/review/shared/hooks/useVisibilityColumns";
 
 export default function Extraction() {
   const [searchString, setSearchString] = useState<string>("");
   const [showSelected, setShowSelected] = useState<boolean>(false);
   const selectionContext = useContext(StudySelectionContext);
-
   const { value: selectedStatus, handleChange: handleSelectChange } =
     useInputState<string | null>(null);
   const { layout, handleChangeLayout } = useLayoutPage();
-
   const { columnsVisible, toggleColumnVisibility } = useVisibiltyColumns({
     page: "Extraction",
   });
@@ -45,10 +43,9 @@ export default function Extraction() {
   const isLoading = selectionContext?.isLoading ?? false;
 
   const allArticles: ArticleInterface[] = useMemo(() => {
-    return safeArticles.filter(
-      (art): art is ArticleInterface =>
-        "studyReviewId" in art && art.selectionStatus == "INCLUDED"
-    );
+    return safeArticles
+      .filter((art): art is ArticleInterface => "studyReviewId" in art)
+      .filter((art) => art.selectionStatus === "INCLUDED");
   }, [safeArticles]);
 
   const startFilteredArticles = useFilterReviewArticles(
@@ -68,96 +65,54 @@ export default function Extraction() {
     return startFilteredArticles;
   }, [showSelected, startFilteredArticles, safeSelectedArticles]);
 
-  const statusCounts = useMemo(() => {
-    const counts: Record<string, number> = {
-      INCLUDED: 0,
-      DUPLICATED: 0,
-      EXCLUDED: 0,
-      UNCLASSIFIED: 0,
-    };
-
-    allArticles.forEach((article) => {
-      const status = article.extractionStatus as keyof typeof counts;
-      if (status && counts[status] !== undefined) {
-        counts[status] += 1;
-      }
-    });
-
-    return counts;
-  }, [allArticles]);
-
-  const statusOptions = [
-    { value: "INCLUDED", label: `Included (${statusCounts.INCLUDED})` },
-    { value: "DUPLICATED", label: `Duplicated (${statusCounts.DUPLICATED})` },
-    { value: "EXCLUDED", label: `Excluded (${statusCounts.EXCLUDED})` },
-    {
-      value: "UNCLASSIFIED",
-      label: `Unclassified (${statusCounts.UNCLASSIFIED})`,
-    },
-  ];
-
   return (
     <FlexLayout navigationType="Accordion">
-      <Box w="100%" px="1rem" py=".75rem" h="fit-content">
-        <Flex
-          w="100%"
-          h="2.5rem"
-          justifyContent="space-between"
-          alignItems="center"
-          mb="2rem"
-        >
-          <Header text="Extraction" />
-          <SelectLayout handleChangeLayout={handleChangeLayout} />
-        </Flex>
-        <Box sx={inputconteiner}>
-          <Flex gap="1rem" w="35%" justifyContent="space-between">
-            <InputText
-              type="search"
-              placeholder="Insert article atribute"
-              nome="search"
-              onChange={(e) => setSearchString(e.target.value)}
-              value={searchString}
-            />
-            {layout !== "article" ? (
-              <ButtonsForMultipleSelection
-                onShowSelectedArticles={setShowSelected}
-                isShown={showSelected}
-              />
-            ) : null}
+      <Box w="98%" m="1rem" h="fit-content">
+        <Flex flexDirection="column" w="100%" h="100%" justifyContent="space-between">
+          <Flex w="100%" h="2.5rem" justifyContent="space-between" alignItems="center" mb="2rem">
+            <Header text="Extraction" />
+            <SelectLayout handleChangeLayout={handleChangeLayout} />
           </Flex>
-          <Box
-            display="flex"
-            gap="1rem"
-            justifyContent="space-between"
-            alignItems="center"
-          >
-            <ColumnVisibilityMenu
+          <Box sx={inputconteiner}>
+            <Flex gap="1rem" w="35%" justifyContent="space-between">
+              <InputText
+                type="search"
+                placeholder="Insert article atribute"
+                nome="search"
+                onChange={(e) => setSearchString(e.target.value)}
+                value={searchString}
+              />
+              {layout !== "article" && (
+                <ButtonsForMultipleSelection
+                  onShowSelectedArticles={setShowSelected}
+                  isShown={showSelected}
+                />
+              )}
+            </Flex>
+            <Box display="flex" gap="1rem" justifyContent="space-between" alignItems="center">
+              <ColumnVisibilityMenu
+                columnsVisible={columnsVisible}
+                toggleColumnVisibility={toggleColumnVisibility}
+              />
+              <StatusSelect
+                articles={allArticles}
+                selectedValue={selectedStatus}
+                onSelect={handleSelectChange}
+                page="Extraction"
+                placeholder="Extraction status"
+              />
+            </Box>
+          </Box>
+          <Box w="100%" h="82.5vh">
+            <LayoutFactory
+              page="Extraction"
+              articles={finalFilteredArticles}
               columnsVisible={columnsVisible}
-              toggleColumnVisibility={toggleColumnVisibility}
-            />
-            <SelectInput
-              names={statusOptions.map((opt) => opt.label)}
-              values={statusOptions.map((opt) => opt.value)}
-              onSelect={(value) => handleSelectChange(value)}
-              selectedValue={selectedStatus}
-              page={"extraction"}
-              placeholder="Extraction status"
+              layout={layout}
+              isLoading={isLoading}
             />
           </Box>
-        </Box>
-      </Box>
-      <Box
-        w="calc(100% - 1.25rem)"
-        h="calc(100vh - 10rem)"
-        padding="0 0 0 .5rem"
-      >
-        <LayoutFactory
-          page="Extraction"
-          articles={finalFilteredArticles}
-          columnsVisible={columnsVisible}
-          layout={layout}
-          isLoading={isLoading}
-        />
+        </Flex>
       </Box>
     </FlexLayout>
   );

--- a/src/features/review/execution-selection/pages/Selection/index.tsx
+++ b/src/features/review/execution-selection/pages/Selection/index.tsx
@@ -9,33 +9,31 @@ import StudySelectionContext from "@features/review/shared/context/StudiesSelect
 import useInputState from "@features/review/shared/hooks/useInputState";
 import useLayoutPage from "../../../shared/hooks/useLayoutPage";
 import { useFilterReviewArticles } from "../../../shared/hooks/useFilterReviewArticles";
+import useVisibiltyColumns from "@features/review/shared/hooks/useVisibilityColumns";
 
 // Components
 import Header from "../../../../../components/structure/Header/Header";
 import FlexLayout from "../../../../../components/structure/Flex/Flex";
 import InputText from "../../../../../components/common/inputs/InputText";
-import SelectInput from "../../../../../components/common/inputs/SelectInput";
 import LayoutFactory from "../../../shared/components/structure/LayoutFactory";
-import ButtonsForMultipleSelection from "../../../shared/components/common/buttons/ButtonsForMultipleSelection";
 import SelectLayout from "../../../shared/components/structure/LayoutButton";
 import ColumnVisibilityMenu from "@features/review/shared/components/common/menu/ColumnVisibilityMenu";
+import StatusSelect from "@features/review/shared/components/common/inputs/StatusSelect";
+import ButtonsForMultipleSelection from "@features/review/shared/components/common/buttons/ButtonsForMultipleSelection";
 
 // Styles
 import { inputconteiner } from "../../../shared/styles/executionStyles";
 
 // Types
 import type ArticleInterface from "../../../shared/types/ArticleInterface";
-import useVisibiltyColumns from "@features/review/shared/hooks/useVisibilityColumns";
 
 export default function Selection() {
   const [searchString, setSearchString] = useState<string>("");
   const [showSelected, setShowSelected] = useState<boolean>(false);
   const selectionContext = useContext(StudySelectionContext);
-
   const { value: selectedStatus, handleChange: handleSelectChange } =
     useInputState<string | null>(null);
   const { layout, handleChangeLayout } = useLayoutPage();
-
   const { columnsVisible, toggleColumnVisibility } = useVisibiltyColumns({
     page: "Selection",
   });
@@ -67,96 +65,54 @@ export default function Selection() {
     return startFilteredArticles;
   }, [showSelected, startFilteredArticles, safeSelectedArticles]);
 
-  const statusCounts = useMemo(() => {
-    const counts: Record<string, number> = {
-      INCLUDED: 0,
-      DUPLICATED: 0,
-      EXCLUDED: 0,
-      UNCLASSIFIED: 0,
-    };
-
-    allArticles.forEach((article) => {
-      const status = article.selectionStatus as keyof typeof counts;
-      if (status && counts[status] !== undefined) {
-        counts[status] += 1;
-      }
-    });
-
-    return counts;
-  }, [allArticles]);
-
-  const statusOptions = [
-    { value: "INCLUDED", label: `Included (${statusCounts.INCLUDED})` },
-    { value: "DUPLICATED", label: `Duplicated (${statusCounts.DUPLICATED})` },
-    { value: "EXCLUDED", label: `Excluded (${statusCounts.EXCLUDED})` },
-    {
-      value: "UNCLASSIFIED",
-      label: `Unclassified (${statusCounts.UNCLASSIFIED})`,
-    },
-  ];
-
   return (
     <FlexLayout navigationType="Accordion">
-      <Box w="100%" px="1rem" py=".75rem" h="fit-content">
-        <Flex
-          w="100%"
-          h="2.5rem"
-          justifyContent="space-between"
-          alignItems="center"
-          mb="2rem"
-        >
-          <Header text="Selection" />
-          <SelectLayout handleChangeLayout={handleChangeLayout} />
-        </Flex>
-        <Box sx={inputconteiner}>
-          <Flex gap="1rem" w="35%" justifyContent="space-between">
-            <InputText
-              type="search"
-              placeholder="Insert article atribute"
-              nome="search"
-              onChange={(e) => setSearchString(e.target.value)}
-              value={searchString}
-            />
-            {layout !== "article" ? (
-              <ButtonsForMultipleSelection
-                onShowSelectedArticles={setShowSelected}
-                isShown={showSelected}
-              />
-            ) : null}
+      <Box w="98%" m="1rem" h="fit-content">
+        <Flex flexDirection="column" w="100%" h="100%" justifyContent="space-between">
+          <Flex w="100%" h="2.5rem" justifyContent="space-between" alignItems="center" mb="2rem">
+            <Header text="Selection" />
+            <SelectLayout handleChangeLayout={handleChangeLayout} />
           </Flex>
-          <Box
-            display="flex"
-            gap="1rem"
-            justifyContent="space-between"
-            alignItems="center"
-          >
-            <ColumnVisibilityMenu
+          <Box sx={inputconteiner}>
+            <Flex gap="1rem" w="35%" justifyContent="space-between">
+              <InputText
+                type="search"
+                placeholder="Insert article atribute"
+                nome="search"
+                onChange={(e) => setSearchString(e.target.value)}
+                value={searchString}
+              />
+              {layout !== "article" && (
+                <ButtonsForMultipleSelection
+                  onShowSelectedArticles={setShowSelected}
+                  isShown={showSelected}
+                />
+              )}
+            </Flex>
+            <Box display="flex" gap="1rem" justifyContent="space-between" alignItems="center">
+              <ColumnVisibilityMenu
+                columnsVisible={columnsVisible}
+                toggleColumnVisibility={toggleColumnVisibility}
+              />
+              <StatusSelect
+                articles={allArticles}
+                selectedValue={selectedStatus}
+                onSelect={handleSelectChange}
+                page="Selection"
+                placeholder="Selection status"
+              />
+            </Box>
+          </Box>
+          <Box w="100%" h="82.5vh">
+            <LayoutFactory
+              page="Selection"
+              articles={finalFilteredArticles}
               columnsVisible={columnsVisible}
-              toggleColumnVisibility={toggleColumnVisibility}
-            />
-            <SelectInput
-              names={statusOptions.map((opt) => opt.label)}
-              values={statusOptions.map((opt) => opt.value)}
-              onSelect={(value) => handleSelectChange(value)}
-              selectedValue={selectedStatus}
-              page={"selection"}
-              placeholder="Selection status"
+              layout={layout}
+              isLoading={isLoading}
             />
           </Box>
-        </Box>
-      </Box>
-      <Box
-        w="calc(100% - 1.25rem)"
-        h="calc(100vh - 10rem)"
-        padding="0 0 0 .5rem"
-      >
-        <LayoutFactory
-          page="Selection"
-          articles={finalFilteredArticles}
-          columnsVisible={columnsVisible}
-          layout={layout}
-          isLoading={isLoading}
-        />
+        </Flex>
       </Box>
     </FlexLayout>
   );

--- a/src/features/review/shared/components/common/inputs/StatusSelect/index.tsx
+++ b/src/features/review/shared/components/common/inputs/StatusSelect/index.tsx
@@ -1,0 +1,158 @@
+import { FormControl, Menu, MenuButton, MenuList, MenuItem, Button, HStack, Text, Box, Divider, Portal } from "@chakra-ui/react";
+import { ChevronDownIcon } from "@chakra-ui/icons";
+import { useEffect, useRef, useState, ReactNode } from "react";
+import { FaCheckCircle, FaCopy, FaQuestionCircle, FaRegCircle, FaTimes } from "react-icons/fa";
+import type ArticleInterface from "@features/review/shared/types/ArticleInterface";
+
+type StatusKey = "INCLUDED" | "DUPLICATED" | "EXCLUDED" | "UNCLASSIFIED";
+
+interface StatusSelectProps {
+  articles: ArticleInterface[];
+  selectedValue: string | null;
+  onSelect: (value: string | null) => void;
+  page: "Selection" | "Extraction";
+  placeholder?: string;
+}
+
+const colors = {
+  background: "#EBF0F3",
+  text: "#2E4B6C",
+  hover: "rgb(144, 205, 244)",
+  selected: "rgb(190, 227, 248)",
+  clearFilters: "rgb(38, 60, 86)",
+};
+
+const iconConfig: Record<
+  Lowercase<StatusKey>,
+  { icon: ReactNode; bg: string }> = {
+  included: { icon: <FaCheckCircle color="white" size="12px" />, bg: "green" },
+  duplicated: { icon: <FaCopy color="white" size="12px" />, bg: "blue" },
+  excluded: { icon: <FaTimes color="white" size="12px" />, bg: "red" },
+  unclassified: {icon: <FaQuestionCircle color="white" size="12px" />, bg: "gold"}
+};
+
+const getIcon = (status: string) => {
+  const cfg = iconConfig[status.toLowerCase() as Lowercase<StatusKey>];
+  if (!cfg) return <FaRegCircle color="gray" />;
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      w="20px"
+      h="20px"
+      borderRadius="50%"
+      bg={cfg.bg}
+    >
+      {cfg.icon}
+    </Box>
+  );
+};
+
+export default function StatusSelect({
+  articles,
+  selectedValue,
+  onSelect,
+  page,
+  placeholder = "Select status",
+}: StatusSelectProps) {
+  const btnRef = useRef<HTMLButtonElement | null>(null);
+  const [menuWidth, setMenuWidth] = useState<number>(0);
+
+  const counts: Record<StatusKey, number> = {
+    INCLUDED: 0,
+    DUPLICATED: 0,
+    EXCLUDED: 0,
+    UNCLASSIFIED: 0,
+  };
+
+  articles.forEach((a) => {
+    const status =
+      page === "Selection" ? a.selectionStatus : a.extractionStatus;
+    if (status && counts[status as StatusKey] !== undefined) {
+      counts[status as StatusKey] += 1;
+    }
+  });
+
+  const options = [
+    { value: "INCLUDED", label: `Included (${counts.INCLUDED})` },
+    { value: "DUPLICATED", label: `Duplicated (${counts.DUPLICATED})` },
+    { value: "EXCLUDED", label: `Excluded (${counts.EXCLUDED})` },
+    { value: "UNCLASSIFIED", label: `Unclassified (${counts.UNCLASSIFIED})` },
+  ];
+
+  const selectedLabel = selectedValue
+    ? options.find((o) => o.value === selectedValue)?.label
+    : placeholder;
+
+  useEffect(() => {
+    const update = () => setMenuWidth(btnRef.current?.offsetWidth ?? 0);
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, [selectedLabel]);
+
+  return (
+    <FormControl w="20rem">
+      <Menu isLazy>
+        <MenuButton
+          ref={btnRef}
+          as={Button}
+          bgColor={colors.background}
+          color={colors.text}
+          rightIcon={<ChevronDownIcon />}
+          w="100%"
+          textAlign="left"
+          fontWeight="normal"
+        >
+          {selectedLabel}
+        </MenuButton>
+        <Portal>
+          <MenuList
+            minW="unset"
+            w={menuWidth ? `${menuWidth}px` : "100%"}
+            maxW={menuWidth ? `${menuWidth}px` : "100%"}
+            zIndex={1400}
+            p={0}
+            boxShadow="none"
+            overflow="hidden"
+          >
+            {options.map((opt) => {
+              const isSelected = opt.value === selectedValue;
+              return (
+                <MenuItem
+                  key={opt.value}
+                  onClick={() => onSelect(opt.value)}
+                  w="100%"
+                  bg={isSelected ? colors.selected : "transparent"}
+                  _hover={{ bg: colors.hover }}
+                >
+                  <HStack w="100%" spacing={3}>
+                    {getIcon(opt.value)}
+                    <Text flex="1" textAlign="left" color={colors.text}>
+                      {opt.label.replace(/\s*\(\d+\)/, "")}
+                    </Text>
+                    <Box minW="2rem" textAlign="right" color={colors.text}>
+                      {opt.label.match(/\((\d+)\)/)?.[1]}
+                    </Box>
+                  </HStack>
+                </MenuItem>
+              );
+            })}
+            <Divider borderColor="gray.300" />
+            <MenuItem onClick={() => onSelect(null)} w="100%">
+              <Text
+                flex={1}
+                textAlign="center"
+                fontWeight="semibold"
+                color={colors.clearFilters}
+              >
+                Clear filters
+              </Text>
+            </MenuItem>
+          </MenuList>
+        </Portal>
+      </Menu>
+    </FormControl>
+  );
+}

--- a/src/features/review/shared/components/common/tables/ArticlesTable/subcomponents/Expanded/subcomponents/Resizable/index.tsx
+++ b/src/features/review/shared/components/common/tables/ArticlesTable/subcomponents/Expanded/subcomponents/Resizable/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 
 interface ResizeHandlerProps {
-  ref: React.RefObject<HTMLDivElement | null>;
+  ref: React.RefObject<HTMLDivElement>;
   isResizing: boolean;
 }
 


### PR DESCRIPTION
## Refatoração dos componentes Selection, Extraction e StatusSelect

### Este PR refatora e padroniza a implementação dos componentes relacionados à seleção e extração de artigos.

### Selection e Extraction
- Estrutura simplificada e remoção de wrappers desnecessários.
- Ajustes de layout para consistência visual e melhor manutenção.

### StatusSelect
- Unificação do StatusSelectInput em um único componente.
- Inclusão de contagem dinâmica de artigos por status.
- Adição de ícones para cada status com cores padronizadas.
- Melhorias na estilização (placeholder, estados selecionado e hover).

### Impactos
- Código mais limpo e organizado.
- Redução de duplicação de lógica.
- Experiência de usuário mais consistente entre telas de seleção e extração.