### PR TITLE
feat: add editable reference code field before table content

### DIFF
--- a/src/features/review/planning-protocol/components/common/inputs/referenceTableSection/index.tsx
+++ b/src/features/review/planning-protocol/components/common/inputs/referenceTableSection/index.tsx
@@ -1,0 +1,54 @@
+import { FormControl,Flex,Heading,Accordion,AccordionItem,AccordionButton,AccordionPanel,Box } from "@chakra-ui/react";
+import AddTextTable from "@features/review/planning-protocol/components/common/inputs/text/AddTextTable";
+
+interface ReferenceTableSectionProps {
+  title: string;
+  placeholder: string;
+  defaultOpen?: boolean;
+}
+
+export default function ReferenceTableSection({
+  title,
+  placeholder,
+  defaultOpen = true,
+}: ReferenceTableSectionProps) {
+  return (
+    <Accordion defaultIndex={defaultOpen ? [0] : [-1]} allowToggle w="100%">
+      <AccordionItem
+        border="1px solid #E2E8F0"
+        borderRadius="lg"
+        overflow="hidden"
+        boxShadow="sm"
+        transition="all 0.2s ease-in-out"
+        _hover={{ boxShadow: "md" }}
+        bg="white"
+      >
+        <AccordionButton
+          _expanded={{ bg: "#EDF2F7" }}
+          borderTopRadius="lg"
+          px={6}
+          py={4}
+        >
+          <Box flex="1" textAlign="center">
+            <Heading size="md" color="#2E4B6C">
+              {title}
+            </Heading>
+          </Box>
+        </AccordionButton>
+
+        <AccordionPanel
+          pb={6}
+          px={6}
+          borderTop="1px solid #E2E8F0"
+          borderBottomRadius="lg"
+        >
+          <Flex direction="column" gap={4}>
+            <FormControl>
+              <AddTextTable text={title} placeholder={placeholder} />
+            </FormControl>
+          </Flex>
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  );
+}

--- a/src/features/review/planning-protocol/components/common/inputs/text/AddTextTable/index.tsx
+++ b/src/features/review/planning-protocol/components/common/inputs/text/AddTextTable/index.tsx
@@ -7,9 +7,10 @@ import InfosTable from "@features/review/planning-protocol/components/common/tab
 interface AddTextTableProps {
   text: string;
   placeholder: string;
+  referencePrefix?: string;
 }
 
-export default function AddTextTable({ text, placeholder }: AddTextTableProps) {
+export default function AddTextTable({ text, placeholder, referencePrefix = ""}: AddTextTableProps) {
   const { AddText, handleAddText, setAddText } = useAddText(text);
   const { handleDeleteText } = useDeleteText(text);
   return (
@@ -18,11 +19,12 @@ export default function AddTextTable({ text, placeholder }: AddTextTableProps) {
         <FormLabel mt={"30px"} fontWeight={500} fontSize={"large"}>{text}</FormLabel>
         <InfosTable
           typeField={""}
-          onAddText={handleAddText}
+          onAddText={(value) => handleAddText(value)}
           onDeleteAddedText={(index) => handleDeleteText(index, setAddText)}
           AddTexts={AddText}
           context={text}
           placeholder={placeholder}
+          referencePrefix={referencePrefix}
         />
       </FormControl>
     </FormControl>

--- a/src/features/review/planning-protocol/components/common/tables/InfosTable/index.tsx
+++ b/src/features/review/planning-protocol/components/common/tables/InfosTable/index.tsx
@@ -14,6 +14,7 @@ interface InfosTableProps {
   typeField: string;
   context: string;
   placeholder: string;
+  referencePrefix?: string;
 }
 
 export default function InfosTable({
@@ -23,6 +24,7 @@ export default function InfosTable({
   typeField,
   context,
   placeholder,
+  referencePrefix = "",
 }: InfosTableProps) {
   const { sendAddText } = useCreateProtocol();
   const { editIndex, handleEdit, handleSaveEdit, editedValue, handleChange } =
@@ -34,14 +36,32 @@ export default function InfosTable({
       },
     });
 
-const [newText, setNewText] = useState("");
+  const [newText, setNewText] = useState("");
+  const [referenceCode, setReferenceCode] = useState("");
+  const [usedCodes, setUsedCodes] = useState<string[]>([]);
 
-const handleAddText = () => {
-  if (newText.trim() !== "") {
-    onAddText(newText);
+  const generateNextCode = () => {
+    const nextNumber = usedCodes.length + 1;
+    return `${referencePrefix}-${String(nextNumber).padStart(2, "0")}`;
+  };
+
+  const handleAddText = () => {
+    const trimmedText = newText.trim();
+    if (trimmedText === "") return;
+
+    const code = referenceCode || generateNextCode();
+
+    if (usedCodes.includes(code)) {
+      alert("Esse código de referência já está em uso!");
+      return;
+    }
+
+    const entry = `${code}: ${trimmedText}`;
+    onAddText(entry);
+    setUsedCodes((prev) => [...prev, code]);
     setNewText("");
-  }
-};
+    setReferenceCode("");
+  };
 
   return (
     <TableContainer sx={tbConteiner}>
@@ -51,10 +71,17 @@ const handleAddText = () => {
             <Td colSpan={2} padding="1rem">
               <Flex gap="4">
                 <Input
+                  placeholder={`${referencePrefix}-01`}
+                  value={referenceCode}
+                  onChange={(e) => setReferenceCode(e.target.value.toUpperCase().trim())}
+                  w="15%"
+                />
+                <Input
                   placeholder={placeholder}
                   value={newText}
                   onChange={(e) => setNewText(e.target.value)}
                   onKeyDown={(e) => e.key === 'Enter' && handleAddText()}
+                  flex="1"
                 />
                 <EventButton text="Add" event={handleAddText} w={"2%"} />
               </Flex>
@@ -76,14 +103,14 @@ const handleAddText = () => {
                   index={index}
                   handleDelete={() => onDeleteAddedText(index)}
                 />
-                {typeField !== "select" ? (
+                {typeField !== "select" && (
                   <EditButton
                     index={index}
                     editIndex={editIndex}
                     handleEdit={() => handleEdit(index)}
                     handleSaveEdit={handleSaveEdit}
                   />
-                ) : null}
+                )}
               </Td>
             </Tr>
           ))}

--- a/src/features/review/planning-protocol/pages/EligibilityCriteria/index.tsx
+++ b/src/features/review/planning-protocol/pages/EligibilityCriteria/index.tsx
@@ -55,10 +55,12 @@ export default function EligibilityCriteria() {
         <AddTextTable
           text="Inclusion criteria"
           placeholder="Enter the criteria"
+          referencePrefix="IC"
         />
         <AddTextTable
           text="Exclusion criteria"
           placeholder="Enter the criteria"
+          referencePrefix="EC"
         />
         <TextAreaInput
           value={studyTypeDefinition}

--- a/src/features/review/planning-protocol/pages/InformationSourcesAndSearchStrategy/index.tsx
+++ b/src/features/review/planning-protocol/pages/InformationSourcesAndSearchStrategy/index.tsx
@@ -86,6 +86,7 @@ export default function InformationSourcesAndSearchStrategy() {
         <AddTextTable
           text="Keywords"
           placeholder="Enter the keywords related to your review"
+          referencePrefix="K"
         />
         <TextAreaInput
           value={searchString}

--- a/src/features/review/planning-protocol/pages/Picoc/index.tsx
+++ b/src/features/review/planning-protocol/pages/Picoc/index.tsx
@@ -36,7 +36,7 @@ return (
     >
       <TextAreaInput
         value={population}
-        label="Population:"
+        label="Population"
         placeholder="What is your study population?"
         onChange={(event) => {
           handleChangePicoc("population", event.target.value);
@@ -44,7 +44,7 @@ return (
       />
       <TextAreaInput
         value={intervention}
-        label="Intervention:"
+        label="Intervention"
         placeholder="What is your intervention?"
         onChange={(event) => {
           handleChangePicoc("intervention", event.target.value);
@@ -52,7 +52,7 @@ return (
       />
       <TextAreaInput
         value={control}
-        label="Control:"
+        label="Control"
         placeholder="What is your control?"
         onChange={(event) => {
           handleChangePicoc("control", event.target.value);
@@ -60,7 +60,7 @@ return (
       />
       <TextAreaInput
         value={outcome}
-        label="Outcome:"
+        label="Outcome"
         placeholder="What is your outcome?"
         onChange={(event) => {
           handleChangePicoc("outcome", event.target.value);
@@ -68,7 +68,7 @@ return (
       />
       <TextAreaInput
         value={context}
-        label="Context:"
+        label="Context"
         placeholder="What is your context?"
         onChange={(event) => {
           handleChangePicoc("context", event.target.value);

--- a/src/features/review/planning-protocol/pages/ResearchQuestions/index.tsx
+++ b/src/features/review/planning-protocol/pages/ResearchQuestions/index.tsx
@@ -82,6 +82,7 @@ export default function ResearchQuestions() {
               <AddTextTable
                 text="Research Questions"
                 placeholder="Enter the other Research Questions"
+                referencePrefix="RQ"
               />
             </Flex>
           </AccordionPanel>


### PR DESCRIPTION
## Descrição
- Adiciona um campo de código de referência nas tabelas das seções do protocolo.
- O campo aparece antes do conteúdo principal e permite inserir ou editar (ex: RQ-01).
## Principais mudanças:
- Inclusão do campo de código de referência.
- Atualização da renderização e estados relacionados.
## Resultado:
- Melhora a organização e identificação dos itens nas tabelas, mantendo consistência e integridade dos dados.