### PR TITLE
feat(protocol-sections): add unique reference code field to section tables

### DIFF
--- a/src/features/review/planning-protocol/components/common/inputs/referenceTableSection/index.tsx
+++ b/src/features/review/planning-protocol/components/common/inputs/referenceTableSection/index.tsx
@@ -1,0 +1,54 @@
+import { FormControl, Flex, Heading, Accordion, AccordionItem, AccordionButton, AccordionPanel, Box } from "@chakra-ui/react";
+import AddTextTable from "@features/review/planning-protocol/components/common/inputs/text/AddTextTable";
+
+interface ReferenceTableSectionProps {
+    title: string;
+    placeholder: string;
+    defaultOpen?: boolean;
+}
+
+export default function ReferenceTableSection({
+    title,
+    placeholder,
+    defaultOpen = true,
+}: ReferenceTableSectionProps) {
+    return (
+        <Accordion defaultIndex={defaultOpen ? [0] : [-1]} allowToggle w="100%">
+            <AccordionItem
+                border="1px solid #E2E8F0"
+                borderRadius="lg"
+                overflow="hidden"
+                boxShadow="sm"
+                transition="all 0.2s ease-in-out"
+                _hover={{ boxShadow: "md" }}
+                bg="white"
+            >
+                <AccordionButton
+                    _expanded={{ bg: "#EDF2F7" }}
+                    borderTopRadius="lg"
+                    px={6}
+                    py={4}
+                >
+                    <Box flex="1" textAlign="center">
+                        <Heading size="md" color="#2E4B6C">
+                            {title}
+                        </Heading>
+                    </Box>
+                </AccordionButton>
+
+                <AccordionPanel
+                    pb={6}
+                    px={6}
+                    borderTop="1px solid #E2E8F0"
+                    borderBottomRadius="lg"
+                >
+                    <Flex direction="column" gap={4}>
+                        <FormControl>
+                            <AddTextTable text={title} placeholder={placeholder} />
+                        </FormControl>
+                    </Flex>
+                </AccordionPanel>
+            </AccordionItem>
+        </Accordion>
+    );
+}

--- a/src/features/review/planning-protocol/components/common/inputs/text/AddTextTable/index.tsx
+++ b/src/features/review/planning-protocol/components/common/inputs/text/AddTextTable/index.tsx
@@ -7,9 +7,10 @@ import InfosTable from "@features/review/planning-protocol/components/common/tab
 interface AddTextTableProps {
   text: string;
   placeholder: string;
+  referencePrefix?: string;
 }
 
-export default function AddTextTable({ text, placeholder }: AddTextTableProps) {
+export default function AddTextTable({ text, placeholder, referencePrefix = "" }: AddTextTableProps) {
   const { AddText, handleAddText, setAddText } = useAddText(text);
   const { handleDeleteText } = useDeleteText(text);
   return (
@@ -18,11 +19,13 @@ export default function AddTextTable({ text, placeholder }: AddTextTableProps) {
         <FormLabel mt={"30px"} fontWeight={500} fontSize={"large"}>{text}</FormLabel>
         <InfosTable
           typeField={""}
-          onAddText={handleAddText}
+          onAddText={(value) => handleAddText(value)}
           onDeleteAddedText={(index) => handleDeleteText(index, setAddText)}
           AddTexts={AddText}
           context={text}
           placeholder={placeholder}
+          referencePrefix={referencePrefix}
+          setAddTexts={setAddText}
         />
       </FormControl>
     </FormControl>

--- a/src/features/review/planning-protocol/components/common/tables/InfosTable/index.tsx
+++ b/src/features/review/planning-protocol/components/common/tables/InfosTable/index.tsx
@@ -1,19 +1,21 @@
 import EditButton from "@components/common/buttons/EditButton";
 import DeleteButton from "@components/common/buttons/DeleteButton";
 import { useEditState } from "@features/review/planning-protocol/hooks/useEdit";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { tbConteiner } from "./styles";
-import { Table, Tbody, Tr, Td, TableContainer, Input, Flex, Thead } from "@chakra-ui/react";
+import { Table,Tbody,Tr,Td,TableContainer,Input,Flex,Thead,Box } from "@chakra-ui/react";
 import useCreateProtocol from "@features/review/planning-protocol/services/useCreateProtocol";
 import EventButton from "@components/common/buttons/EventButton";
 
 interface InfosTableProps {
   AddTexts: string[];
-  onDeleteAddedText: (index: number) => void;
-  onAddText: (newText : string) => void;
+  onDeleteAddedText?: (index: number) => void;
+  onAddText: (newText: string) => void;
   typeField: string;
   context: string;
   placeholder: string;
+  referencePrefix?: string;
+  setAddTexts?: (arr: string[]) => void;
 }
 
 export default function InfosTable({
@@ -23,25 +25,105 @@ export default function InfosTable({
   typeField,
   context,
   placeholder,
+  referencePrefix = "",
+  setAddTexts,
 }: InfosTableProps) {
   const { sendAddText } = useCreateProtocol();
   const { editIndex, handleEdit, handleSaveEdit, editedValue, handleChange } =
     useEditState({
       AddTexts,
-      onSaveEdit: (editedValue, editIndex) => {
-        AddTexts[editIndex] = editedValue;
-        sendAddText(AddTexts, context);
+      onSaveEdit: (editedValue: string, editIndex: number) => {
+        const newCode = (editedValue.split(":")[0] || "").trim().toUpperCase();
+        if (!newCode) {
+          alert("O código de referência não pode estar vazio.");
+          return;
+        }
+        const duplicate = AddTexts.some((item, i) => {
+          if (i === editIndex) return false;
+          const code = (item.split(":")[0] || "").trim().toUpperCase();
+          return code === newCode;
+        });
+        if (duplicate) {
+          alert("Código de referência duplicado. Escolha outro código.");
+          return;
+        }
+
+        const updated = [...AddTexts];
+        updated[editIndex] = editedValue;
+        sendAddText(updated, context);
+        if (setAddTexts) setAddTexts(updated);
       },
     });
 
-const [newText, setNewText] = useState("");
+  const [newText, setNewText] = useState("");
+  const [usedCodes, setUsedCodes] = useState<string[]>([]);
 
-const handleAddText = () => {
-  if (newText.trim() !== "") {
-    onAddText(newText);
+  useEffect(() => {
+    const codes = AddTexts.map((entry) =>
+      (entry.split(":")[0] || "").trim().toUpperCase()
+    ).filter(Boolean);
+    setUsedCodes(codes);
+  }, [AddTexts]);
+
+  const generateNextCode = () => {
+    const prefix = referencePrefix ? referencePrefix.toUpperCase() : "";
+    const relevant = usedCodes.filter((c) =>
+      prefix ? c.startsWith(prefix + "-") : !c.includes("-")
+    );
+
+    const nums = relevant
+      .map((c) => {
+        const part = prefix ? c.split("-").pop() : c;
+        const n = part ? parseInt(part, 10) : NaN;
+        return Number.isNaN(n) ? null : n;
+      })
+      .filter((n): n is number => n !== null)
+      .sort((a, b) => a - b);
+    for (let i = 1; ; i++) {
+      if (!nums.includes(i)) {
+        const formatted = String(i).padStart(2, "0");
+        return prefix ? `${prefix}-${formatted}` : `${formatted}`;
+      }
+    }
+  };
+
+  const handleAddText = () => {
+    const trimmedText = newText.trim();
+    if (trimmedText === "") return;
+    const code = generateNextCode();
+    if (usedCodes.includes(code.toUpperCase())) {
+      alert("Esse código de referência já está em uso!");
+      return;
+    }
+
+    const entry = `${code}: ${trimmedText}`;
+    onAddText(entry);
+    setUsedCodes((prev: string[]) => [...prev, code.toUpperCase()]);
     setNewText("");
-  }
-};
+  };
+
+  const handleDelete = (index: number) => {
+    const updated = AddTexts.filter((_, i) => i !== index).map((entry, i) => {
+      const parts = entry.split(":");
+      const content = parts.slice(1).join(":").trim();
+      const newNumber = i + 1;
+      const newCode = referencePrefix ? `${referencePrefix.toUpperCase()}-${String(newNumber).padStart(2,"0")}`
+        : `${String(newNumber).padStart(2, "0")}`;
+      return `${newCode}: ${content}`;
+    });
+
+    if (setAddTexts) {
+      setAddTexts(updated);
+    } else if (typeof onDeleteAddedText === "function") {
+      onDeleteAddedText(index);
+    }
+    sendAddText(updated, context);
+
+    const newCodes = updated.map((entry) =>
+      (entry.split(":")[0] || "").trim().toUpperCase()
+    );
+    setUsedCodes(newCodes);
+  };
 
   return (
     <TableContainer sx={tbConteiner}>
@@ -54,7 +136,8 @@ const handleAddText = () => {
                   placeholder={placeholder}
                   value={newText}
                   onChange={(e) => setNewText(e.target.value)}
-                  onKeyDown={(e) => e.key === 'Enter' && handleAddText()}
+                  onKeyDown={(e) => e.key === "Enter" && handleAddText()}
+                  flex="1"
                 />
                 <EventButton text="Add" event={handleAddText} w={"2%"} />
               </Flex>
@@ -62,31 +145,50 @@ const handleAddText = () => {
           </Tr>
         </Thead>
         <Tbody className="tableBody">
-          {AddTexts.map((addText, index) => (
-            <Tr key={index}>
-              <Td whiteSpace={"normal"} wordBreak={"break-word"} py={"1"}>
-                {editIndex === index ? (
-                  <Input value={editedValue} onChange={handleChange} />
-                ) : (
-                  addText
-                )}
-              </Td>
-              <Td textAlign={"right"} py={"1"}>
-                <DeleteButton
-                  index={index}
-                  handleDelete={() => onDeleteAddedText(index)}
-                />
-                {typeField !== "select" ? (
-                  <EditButton
+          {AddTexts.map((addText, index) => {
+            const code = (addText.split(":")[0] || "").trim();
+            const content = addText.split(":").slice(1).join(":").trim();
+            return (
+              <Tr key={index}>
+                <Td whiteSpace={"normal"} wordBreak={"break-word"} py={"1"}>
+                  {editIndex === index ? (
+                    <Flex align="center">
+                      <Input
+                        value={editedValue}
+                        onChange={handleChange}
+                        flex="1"
+                        autoFocus
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            handleSaveEdit();
+                          }
+                        }}
+                      />
+                    </Flex>
+                  ) : (
+                    <Box>
+                      <strong style={{ marginRight: 8 }}>{code}</strong>
+                      <span>{content}</span>
+                    </Box>
+                  )}
+                </Td>
+                <Td textAlign={"right"} py={"1"}>
+                  <DeleteButton
                     index={index}
-                    editIndex={editIndex}
-                    handleEdit={() => handleEdit(index)}
-                    handleSaveEdit={handleSaveEdit}
+                    handleDelete={() => handleDelete(index)}
                   />
-                ) : null}
-              </Td>
-            </Tr>
-          ))}
+                  {typeField !== "select" && (
+                    <EditButton
+                      index={index}
+                      editIndex={editIndex}
+                      handleEdit={() => handleEdit(index)}
+                      handleSaveEdit={handleSaveEdit}
+                    />
+                  )}
+                </Td>
+              </Tr>
+            );
+          })}
         </Tbody>
       </Table>
     </TableContainer>

--- a/src/features/review/planning-protocol/pages/EligibilityCriteria/index.tsx
+++ b/src/features/review/planning-protocol/pages/EligibilityCriteria/index.tsx
@@ -55,10 +55,12 @@ export default function EligibilityCriteria() {
         <AddTextTable
           text="Inclusion criteria"
           placeholder="Enter the criteria"
+          referencePrefix="IC"
         />
         <AddTextTable
           text="Exclusion criteria"
           placeholder="Enter the criteria"
+          referencePrefix="EC"
         />
         <TextAreaInput
           value={studyTypeDefinition}

--- a/src/features/review/planning-protocol/pages/InformationSourcesAndSearchStrategy/index.tsx
+++ b/src/features/review/planning-protocol/pages/InformationSourcesAndSearchStrategy/index.tsx
@@ -86,6 +86,7 @@ export default function InformationSourcesAndSearchStrategy() {
         <AddTextTable
           text="Keywords"
           placeholder="Enter the keywords related to your review"
+          referencePrefix="K"
         />
         <TextAreaInput
           value={searchString}

--- a/src/features/review/planning-protocol/pages/ResearchQuestions/index.tsx
+++ b/src/features/review/planning-protocol/pages/ResearchQuestions/index.tsx
@@ -82,6 +82,7 @@ export default function ResearchQuestions() {
               <AddTextTable
                 text="Research Questions"
                 placeholder="Enter the other Research Questions"
+                referencePrefix="RQ"
               />
             </Flex>
           </AccordionPanel>


### PR DESCRIPTION
## Descrição
- Este PR implementa um campo de código de referência automático nas tabelas das seções do protocolo.
- O código é gerado automaticamente de forma incremental (ex.: RQ-01, RQ-02, RQ-03, ...) conforme novos itens são adicionados à tabela.
- O valor do código só pode ser alterado ao editar o item correspondente na tabela, garantindo controle e integridade sobre as referências.
- Essa melhoria facilita a organização, rastreabilidade e consistência dos itens nas seções do protocolo, evitando duplicações e mantendo um padrão uniforme.

## Objetivos
- Gerar automaticamente um código de referência sequencial e único para cada item.
- Permitir a edição controlada do código apenas ao alterar o item na tabela.
- Evitar duplicações e inconsistências nos códigos.
- Manter a consistência visual e funcional em todas as tabelas do protocolo.