### PR TITLE
feat(priority): remove confusing icons and adjust element padding for better clarity

### DIFF
--- a/src/features/review/planning-protocol/pages/Picoc/index.tsx
+++ b/src/features/review/planning-protocol/pages/Picoc/index.tsx
@@ -36,7 +36,7 @@ return (
     >
       <TextAreaInput
         value={population}
-        label="Population:"
+        label="Population"
         placeholder="What is your study population?"
         onChange={(event) => {
           handleChangePicoc("population", event.target.value);
@@ -44,7 +44,7 @@ return (
       />
       <TextAreaInput
         value={intervention}
-        label="Intervention:"
+        label="Intervention"
         placeholder="What is your intervention?"
         onChange={(event) => {
           handleChangePicoc("intervention", event.target.value);
@@ -52,7 +52,7 @@ return (
       />
       <TextAreaInput
         value={control}
-        label="Control:"
+        label="Control"
         placeholder="What is your control?"
         onChange={(event) => {
           handleChangePicoc("control", event.target.value);
@@ -60,7 +60,7 @@ return (
       />
       <TextAreaInput
         value={outcome}
-        label="Outcome:"
+        label="Outcome"
         placeholder="What is your outcome?"
         onChange={(event) => {
           handleChangePicoc("outcome", event.target.value);
@@ -68,7 +68,7 @@ return (
       />
       <TextAreaInput
         value={context}
-        label="Context:"
+        label="Context"
         placeholder="What is your context?"
         onChange={(event) => {
           handleChangePicoc("context", event.target.value);

--- a/src/features/review/shared/components/common/tables/ArticlesTable/subcomponents/Expanded/index.tsx
+++ b/src/features/review/shared/components/common/tables/ArticlesTable/subcomponents/Expanded/index.tsx
@@ -17,12 +17,6 @@ import {
 import { CheckCircleIcon, QuestionIcon, WarningIcon } from "@chakra-ui/icons";
 import { FaChevronDown, FaChevronUp } from "react-icons/fa6";
 import { IoIosCloseCircle } from "react-icons/io";
-import {
-  MdOutlineKeyboardArrowLeft,
-  MdOutlineKeyboardArrowRight,
-  MdOutlineKeyboardDoubleArrowLeft,
-  MdOutlineKeyboardDoubleArrowRight,
-} from "react-icons/md";
 
 import { RiCheckboxMultipleBlankFill } from "react-icons/ri";
 
@@ -158,21 +152,7 @@ export default function Expanded({
     ),
   };
 
-  const priorityIconMap: Record<string, React.ReactElement> = {
-    VERY_LOW: (
-      <MdOutlineKeyboardDoubleArrowLeft color="#D32F2F" size="1.5rem" />
-    ),
-    LOW: <MdOutlineKeyboardArrowLeft color="#FBC02D" size="1.5rem" />,
-    HIGH: <MdOutlineKeyboardArrowRight color="#F57C00" size="1.5rem" />,
-    VERY_HIGH: (
-      <MdOutlineKeyboardDoubleArrowRight color="#388E3C" size="1.5rem" />
-    ),
-  };
-
   const renderStatusIcon = (status: string) => statusIconMap[status] || null;
-  const renderPriorityIcon = (priority: string) =>
-    priorityIconMap[priority] || null;
-
   const {
     currentPage,
     itensPerPage,
@@ -548,7 +528,7 @@ export default function Expanded({
                     </Td>
                   )}
                   {columnsVisible["score"] && (
-                    <Td sx={tdSX} w={columnWidths.score}>
+                    <Td sx={tdSX} w={columnWidths.score} pl="2rem">
                       <Tooltip
                         sx={tooltip}
                         label={reference.score}
@@ -565,7 +545,7 @@ export default function Expanded({
                     <Td
                       sx={tdSX}
                       w={columnWidths.readingPriority}
-                      pl="0.5rem"
+                      pl="2rem"
                       pr="0.5rem"
                     >
                       <Box
@@ -574,7 +554,6 @@ export default function Expanded({
                         justifyContent="start"
                         gap="0.5rem"
                       >
-                        {renderPriorityIcon(reference.readingPriority)}
                         <Text sx={collapsedSpanTextChanged}>
                           {capitalize(
                             reference.readingPriority


### PR DESCRIPTION
## Descrição
- Remoção dos ícones da coluna Priority, que causavam confusão visual e não transmitiam claramente o nível de prioridade.
- Também foi realizado o ajuste de padding para manter o alinhamento e a consistência visual da tabela.
## Alterações Realizadas
- Removidos os ícones da coluna Priority
- Ajustado o espaçamento interno (padding) do elemento para alinhamento correto
- Mantida a legibilidade e o equilíbrio visual da tabela