### PR TITLE
feat(ui): update priority icons and adjust article table padding

### DIFF
--- a/src/features/review/shared/components/common/tables/ArticlesTable/subcomponents/Expanded/index.tsx
+++ b/src/features/review/shared/components/common/tables/ArticlesTable/subcomponents/Expanded/index.tsx
@@ -15,7 +15,8 @@ import {
 } from "@chakra-ui/react";
 
 import { CheckCircleIcon, QuestionIcon, WarningIcon } from "@chakra-ui/icons";
-import { FaChevronDown, FaChevronUp } from "react-icons/fa6";
+import { FaChevronDown, FaChevronUp} from "react-icons/fa6";
+import { MdOutlineKeyboardArrowLeft, MdOutlineKeyboardArrowRight, MdOutlineKeyboardDoubleArrowLeft, MdOutlineKeyboardDoubleArrowRight } from "react-icons/md";
 import { IoIosCloseCircle } from "react-icons/io";
 
 import { RiCheckboxMultipleBlankFill } from "react-icons/ri";
@@ -83,13 +84,13 @@ export default function Expanded({
   const [columnWidths, setColumnWidths] = useState({
     studyReviewId: "62px",
     title: "150px",
-    authors: "150px",
+    authors: "100px",
     venue: "100px",
-    year: "62px",
-    selectionStatus: "100px",
-    extractionStatus: "100px",
-    score: "62px",
-    readingPriority: "100px",
+    year: "65px",
+    selectionStatus: "90px",
+    extractionStatus: "90px",
+    score: "70px",
+    readingPriority: "80px",
   });
   const studyContext = useContext(StudySelectionContext);
 
@@ -117,13 +118,15 @@ export default function Expanded({
     },
   ];
 
-  const IconWrapper = ({ children }: { children: React.ReactNode }) => (
+  const IconWrapper = ({ children, bg, size = "1.25rem"}: { children: React.ReactNode; bg?: string; size?: string; }) => (
     <Box
       display="flex"
       alignItems="center"
       justifyContent="center"
-      w="1.25rem"
-      h="1.25rem"
+      w={size}
+      h={size}
+      borderRadius="full"
+      bg={bg || "transparent"}
     >
       {children}
     </Box>
@@ -153,6 +156,31 @@ export default function Expanded({
   };
 
   const renderStatusIcon = (status: string) => statusIconMap[status] || null;
+
+  const priorityIconMap: Record<string, React.ReactElement> = {
+    VERY_LOW: (
+      <IconWrapper bg="red.500" size="1rem">
+        <MdOutlineKeyboardDoubleArrowLeft color="white" size="1rem" />
+      </IconWrapper>
+    ),
+    LOW: (
+      <IconWrapper bg="yellow.500" size="1rem">
+        <MdOutlineKeyboardArrowLeft color="white" size="1rem" />
+      </IconWrapper>
+    ),
+    HIGH: (
+      <IconWrapper bg="orange.500" size="1rem">
+        <MdOutlineKeyboardArrowRight color="white" size="1rem" />
+      </IconWrapper>
+    ),
+    VERY_HIGH: (
+      <IconWrapper bg="green.500" size="1rem">
+        <MdOutlineKeyboardDoubleArrowRight color="white" size="1rem" />
+      </IconWrapper>
+    ),
+  };
+  const renderPriorityIcon = (priority: string) => priorityIconMap[priority] || null;
+
   const {
     currentPage,
     itensPerPage,
@@ -277,6 +305,8 @@ export default function Expanded({
                 color="#263C56"
                 w="1rem"
                 bg="white"
+                paddingStart={"2rem"}
+                paddingEnd={"0.3rem"}
               >
                 <RiCheckboxMultipleBlankFill size="1rem" />
               </Th>
@@ -480,7 +510,7 @@ export default function Expanded({
                     </Td>
                   )}
                   {columnsVisible["year"] && (
-                    <Td sx={tdSX} w={columnWidths.year}>
+                    <Td sx={tdSX} w={columnWidths.year} pl={"2.2rem"}>
                       <Tooltip
                         sx={tooltip}
                         label={reference.year}
@@ -532,7 +562,7 @@ export default function Expanded({
                     </Td>
                   )}
                   {columnsVisible["score"] && (
-                    <Td sx={tdSX} w={columnWidths.score} pl="2rem">
+                    <Td sx={tdSX} w={columnWidths.score} pl="3rem">
                       <Tooltip
                         sx={tooltip}
                         label={reference.score}
@@ -555,9 +585,10 @@ export default function Expanded({
                       <Box
                         display="flex"
                         alignItems="center"
-                        justifyContent="start"
-                        gap="0.5rem"
+                        justifyContent="flex-start"
+                        gap="0.7rem"
                       >
+                        {renderPriorityIcon(reference.readingPriority?.toString())}
                         <Text sx={collapsedSpanTextChanged}>
                           {capitalize(
                             reference.readingPriority


### PR DESCRIPTION
## Descrição
Atualiza os ícones da coluna de prioridade para opções mais intuitivas e ajusta o espaçamento (padding) da tabela de artigos para melhorar a legibilidade.

## Alterações
- Substituição dos ícones de prioridade por versões mais claras e consistentes.
- Ajuste no padding da tabela de artigos.

## Objetivo
- Melhorar a compreensão visual dos níveis de prioridade e a aparência geral da tabela.

## Antes

<img width="1628" height="785" alt="image" src="https://github.com/user-attachments/assets/da88b2e8-b554-4626-acc7-39ce74c41fe9" />

## Depois

<img width="1628" height="785" alt="image" src="https://github.com/user-attachments/assets/98c43f13-4ff4-409c-8f61-6965271dd817" />

