### PR TITLE
feat(review): fetch next page silently on article navigation in split view

### DIFF
--- a/src/features/review/execution-extraction/pages/Extraction/index.tsx
+++ b/src/features/review/execution-extraction/pages/Extraction/index.tsx
@@ -151,6 +151,7 @@ export default function Extraction() {
             changeQuantityOfItens,
           }}
           reloadArticles={mutate}
+          extraParams={{ selectionStatus: "INCLUDED" }}
         />
       </Box>
     </FlexLayout>

--- a/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
+++ b/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
@@ -36,6 +36,8 @@ interface ButtonsForSelectionProps {
   isFirstPage: boolean;
   onFetchNextPage: () => Promise<ArticleInterface[]>;
   onFetchPrevPage: () => Promise<ArticleInterface[]>;
+  onWrapToLast: () => Promise<ArticleInterface[]>;
+  onWrapToFirst: () => ArticleInterface[];
 }
 
 type ComboBoxGroup = {
@@ -55,6 +57,8 @@ export default function ButtonsForSelection({
   isFirstPage,
   onFetchNextPage,
   onFetchPrevPage,
+  onWrapToLast,
+  onWrapToFirst,
 }: ButtonsForSelectionProps) {
   const { handleResetStatusToUnclassified } = useResetStatus({ page, reloadArticles });
   const { handleChangePriority } = useChangePriority({ reloadArticles });
@@ -128,6 +132,14 @@ export default function ButtonsForSelection({
       return;
     }
 
+    if (isLastArticleOnPage && isLastPage) {
+      const firstPageArticles = onWrapToFirst();
+      if (firstPageArticles.length > 0) {
+        setSelectedArticleReview(getArticleId(firstPageArticles[0]) as number);
+      }
+      return;
+    }
+
     const nextIndex = (articleIndex + 1) % articles.length;
     setSelectedArticleReview(getArticleId(articles[nextIndex]) as number);
   }
@@ -139,6 +151,15 @@ export default function ButtonsForSelection({
       const prevPageArticles = await onFetchPrevPage();
       if (prevPageArticles.length > 0) {
         const last = prevPageArticles[prevPageArticles.length - 1];
+        setSelectedArticleReview(getArticleId(last) as number);
+      }
+      return;
+    }
+
+    if (isFirstArticleOnPage && isFirstPage) {
+      const lastPageArticles = await onWrapToLast();
+      if (lastPageArticles.length > 0) {
+        const last = lastPageArticles[lastPageArticles.length - 1];
         setSelectedArticleReview(getArticleId(last) as number);
       }
       return;
@@ -179,6 +200,7 @@ export default function ButtonsForSelection({
           </Tooltip>
         </Flex>
       )}
+
       <Flex sx={boxconteiner}>
         {(Object.entries(comboBoxGroups) as [OptionType, ComboBoxGroup][]).map(([groupKey, group]) => (
           <Tooltip

--- a/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
+++ b/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
@@ -22,11 +22,7 @@ import { boxconteiner, buttonconteiner, conteiner } from "./styles";
 import ArticleInterface from "../../../../types/ArticleInterface";
 import { StudyInterface } from "../../../../types/IStudy";
 import { PageLayout } from "../../../structure/LayoutFactory";
-
-import type {
-  OptionProps,
-  OptionType,
-} from "../../../../services/useFetchAllCriteriasByArticle";
+import type { OptionProps, OptionType } from "../../../../services/useFetchAllCriteriasByArticle";
 import { SelectionArticles } from "@features/review/execution-selection/services/useFetchSelectionArticles";
 import { KeyedMutator } from "swr";
 
@@ -36,7 +32,18 @@ interface ButtonsForSelectionProps {
   articleIndex: number;
   setSelectedArticleReview: React.Dispatch<React.SetStateAction<number>>;
   reloadArticles: KeyedMutator<SelectionArticles>;
+  isLastPage: boolean;
+  isFirstPage: boolean;
+  onFetchNextPage: () => Promise<ArticleInterface[]>;
+  onFetchPrevPage: () => Promise<ArticleInterface[]>;
 }
+
+type ComboBoxGroup = {
+  label: string;
+  description: string;
+  options: OptionProps[];
+  isDisabled: boolean;
+};
 
 export default function ButtonsForSelection({
   page,
@@ -44,11 +51,12 @@ export default function ButtonsForSelection({
   articleIndex,
   setSelectedArticleReview,
   reloadArticles,
+  isLastPage,
+  isFirstPage,
+  onFetchNextPage,
+  onFetchPrevPage,
 }: ButtonsForSelectionProps) {
-  const { handleResetStatusToUnclassified } = useResetStatus({
-    page,
-    reloadArticles,
-  });
+  const { handleResetStatusToUnclassified } = useResetStatus({ page, reloadArticles });
   const { handleChangePriority } = useChangePriority({ reloadArticles });
 
   const currentArticle = articles[articleIndex];
@@ -76,11 +84,8 @@ export default function ButtonsForSelection({
 
   const handleFullReset = async () => {
     if (!currentArticleId) return;
-
     await handleResetStatusToUnclassified(currentArticleId, historicalCriteria);
-
     resetLocalCriterias();
-
     if (page === "Selection") {
       setHistoricalCriteria([]);
     }
@@ -95,10 +100,7 @@ export default function ButtonsForSelection({
 
   const criteriaOptions = fetchedCriterias.options;
 
-  const criteriaGroupDataMap: Record<
-    OptionType,
-    { data: OptionProps[]; isActive: boolean }
-  > = {
+  const criteriaGroupDataMap: Record<OptionType, { data: OptionProps[]; isActive: boolean }> = {
     INCLUSION: {
       data: criteriaOptions.INCLUSION.content,
       isActive: criteriaOptions.INCLUSION.isActive,
@@ -109,69 +111,63 @@ export default function ButtonsForSelection({
     },
   };
 
-  if (!criteriaGroupDataMap["INCLUSION"] || !criteriaGroupDataMap["EXCLUSION"])
-    return null;
+  if (!criteriaGroupDataMap["INCLUSION"] || !criteriaGroupDataMap["EXCLUSION"]) return null;
 
   const isInclusionActive = criteriaOptions.INCLUSION.isActive;
   const isExclusionActive = criteriaOptions.EXCLUSION.isActive;
+  const isUniqueArticle = articles.length === 1;
 
-  const isUniqueArticle = articles.length == 1 ? true : false;
+  async function goToNextArticle() {
+    const isLastArticleOnPage = articleIndex === articles.length - 1;
 
-  function goToNextArticle() {
-    const nextIndex = (articleIndex + 1) % articles.length;
-    const nextArticle = articles[nextIndex];
-    const nextId = getArticleId(nextArticle) as number;
-    setSelectedArticleReview(nextId);
-  }
-
-  function goToPreviousArticle() {
-    const prevIndex = (articleIndex - 1 + articles.length) % articles.length;
-    const prevArticle = articles[prevIndex];
-    const prevId = getArticleId(prevArticle) as number;
-    setSelectedArticleReview(prevId);
-  }
-
-  const comboBoxGroups: Record<
-    OptionType,
-    {
-      label: string;
-      description: string;
-      options: OptionProps[];
-      isDisabled: boolean;
+    if (isLastArticleOnPage && !isLastPage) {
+      const nextPageArticles = await onFetchNextPage();
+      if (nextPageArticles.length > 0) {
+        setSelectedArticleReview(getArticleId(nextPageArticles[0]) as number);
+      }
+      return;
     }
-  > = {
+
+    const nextIndex = (articleIndex + 1) % articles.length;
+    setSelectedArticleReview(getArticleId(articles[nextIndex]) as number);
+  }
+
+  async function goToPreviousArticle() {
+    const isFirstArticleOnPage = articleIndex === 0;
+
+    if (isFirstArticleOnPage && !isFirstPage) {
+      const prevPageArticles = await onFetchPrevPage();
+      if (prevPageArticles.length > 0) {
+        const last = prevPageArticles[prevPageArticles.length - 1];
+        setSelectedArticleReview(getArticleId(last) as number);
+      }
+      return;
+    }
+
+    const prevIndex = (articleIndex - 1 + articles.length) % articles.length;
+    setSelectedArticleReview(getArticleId(articles[prevIndex]) as number);
+  }
+
+  const comboBoxGroups: Record<OptionType, ComboBoxGroup> = {
     INCLUSION: {
       label: "Include",
       description: "Add inclusion criteria",
-      isDisabled:
-        criteriaGroupDataMap["INCLUSION"].data.length === 0 ||
-        isExclusionActive,
-      options: criteriaGroupDataMap["INCLUSION"].data || [],
+      isDisabled: criteriaGroupDataMap["INCLUSION"].data.length === 0 || isExclusionActive,
+      options: criteriaGroupDataMap["INCLUSION"].data,
     },
     EXCLUSION: {
       label: "Exclude",
       description: "Add exclusion criteria",
-      isDisabled:
-        criteriaGroupDataMap["EXCLUSION"].data.length === 0 ||
-        isInclusionActive,
-      options: criteriaGroupDataMap["EXCLUSION"].data || [],
+      isDisabled: criteriaGroupDataMap["EXCLUSION"].data.length === 0 || isInclusionActive,
+      options: criteriaGroupDataMap["EXCLUSION"].data,
     },
   };
 
   return (
-    <Flex
-      sx={conteiner}
-      justifyContent={isUniqueArticle ? "center" : "space-between"}
-    >
-      {isUniqueArticle ? null : (
+    <Flex sx={conteiner} justifyContent={isUniqueArticle ? "center" : "space-between"}>
+      {!isUniqueArticle && (
         <Flex sx={buttonconteiner}>
-          <Tooltip
-            label="Previous article"
-            placement="top"
-            hasArrow
-            p=".5rem"
-            borderRadius=".25rem"
-          >
+          <Tooltip label="Previous article" placement="top" hasArrow p=".5rem" borderRadius=".25rem">
             <Box style={{ display: "inline-block" }}>
               <IoIosArrowBack
                 color="black"
@@ -184,7 +180,7 @@ export default function ButtonsForSelection({
         </Flex>
       )}
       <Flex sx={boxconteiner}>
-        {Object.entries(comboBoxGroups).map(([groupKey, group]) => (
+        {(Object.entries(comboBoxGroups) as [OptionType, ComboBoxGroup][]).map(([groupKey, group]) => (
           <Tooltip
             key={groupKey}
             label={group.description}
@@ -198,58 +194,37 @@ export default function ButtonsForSelection({
                 page={page}
                 text={group.label}
                 status={currentArticleStatus}
-                groupKey={groupKey as OptionType}
+                groupKey={groupKey}
                 options={group.options}
                 isDisabled={group.isDisabled}
-                handlerUpdateCriteriasStructure={
-                  handlerUpdateCriteriasStructure
-                }
+                handlerUpdateCriteriasStructure={handlerUpdateCriteriasStructure}
                 reloadArticles={reloadArticles}
                 selectedCriteria={historicalCriteria}
               />
             </Box>
           </Tooltip>
         ))}
-        <Tooltip
-          label="Reset article"
-          placement="top"
-          hasArrow
-          p=".5rem"
-          borderRadius=".25rem"
-        >
+
+        <Tooltip label="Reset article" placement="top" hasArrow p=".5rem" borderRadius=".25rem">
           <Button color="black" bg="white" p="1rem" onClick={handleFullReset}>
             <RiResetLeftLine color="black" size="1.5rem" />
           </Button>
         </Tooltip>
 
-        <Tooltip
-          label="Select reading priority"
-          placement="top"
-          hasArrow
-          p=".5rem"
-          borderRadius=".25rem"
-        >
+        <Tooltip label="Select reading priority" placement="top" hasArrow p=".5rem" borderRadius=".25rem">
           <Box style={{ display: "inline-block" }}>
             <MenuOptions
               options={["Very Low", "Low", "High", "Very High"]}
-              onOptionToggle={(option) =>
-                handleChangePriority({ status: option })
-              }
+              onOptionToggle={(option) => handleChangePriority({ status: option })}
               icon={<MdOutlineLowPriority color="black" size="1.75rem" />}
             />
           </Box>
         </Tooltip>
       </Flex>
 
-      {isUniqueArticle ? null : (
+      {!isUniqueArticle && (
         <Flex sx={buttonconteiner}>
-          <Tooltip
-            label="Next article"
-            placement="top"
-            hasArrow
-            p=".5rem"
-            borderRadius=".25rem"
-          >
+          <Tooltip label="Next article" placement="top" hasArrow p=".5rem" borderRadius=".25rem">
             <Box style={{ display: "inline-block" }}>
               <IoIosArrowForward
                 color="black"

--- a/src/features/review/shared/components/common/layouts/SplitHorizontal/index.tsx
+++ b/src/features/review/shared/components/common/layouts/SplitHorizontal/index.tsx
@@ -72,6 +72,9 @@ export const SplitHorizontal: React.FC<HorizontalProps> = ({
                 articles={articles}
                 page={page}
                 reloadArticles={reloadArticles}
+                currentPage={pagination.currentPage - 1}
+                totalPages={pagination.quantityOfPages}
+                pageSize={pagination.itensPerPage}
               />
             </Box>
           </motion.div>
@@ -140,6 +143,9 @@ export const SplitHorizontal: React.FC<HorizontalProps> = ({
                 articles={articles}
                 page={page}
                 reloadArticles={reloadArticles}
+                currentPage={pagination.currentPage - 1}
+                totalPages={pagination.quantityOfPages}
+                pageSize={pagination.itensPerPage}
               />
             </Box>
           </motion.div>

--- a/src/features/review/shared/components/common/layouts/SplitHorizontal/index.tsx
+++ b/src/features/review/shared/components/common/layouts/SplitHorizontal/index.tsx
@@ -6,23 +6,20 @@ import { Flex, Box } from "@chakra-ui/react";
 import ArticlesTable from "../../tables/ArticlesTable";
 import StudySelectionArea from "../../../structure/StudySelectionArea";
 
-// Hooks
-import { ColumnVisibility } from "@features/review/shared/hooks/useVisibilityColumns";
-
-// Animations
-const horizontalTransitionVariants = {
-  initial: { opacity: 0, y: 5 },
-  animate: { opacity: 1, y: 0, transition: { duration: 0.5 } },
-  exit: { opacity: 0, y: -5, transition: { duration: 0.5 } },
-};
-
 // Types
+import { ColumnVisibility } from "@features/review/shared/hooks/useVisibilityColumns";
 import type { PageLayout } from "../../../structure/LayoutFactory";
 import type { ViewModel } from "../../../../hooks/useLayoutPage";
 import type ArticleInterface from "../../../../types/ArticleInterface";
 import { PaginationControls } from "@features/shared/types/pagination";
 import { SelectionArticles } from "@features/review/execution-selection/services/useFetchSelectionArticles";
 import { KeyedMutator } from "swr";
+
+const horizontalTransitionVariants = {
+  initial: { opacity: 0, y: 5 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.5 } },
+  exit: { opacity: 0, y: -5, transition: { duration: 0.5 } },
+};
 
 interface HorizontalProps {
   isInverted: boolean;
@@ -32,6 +29,7 @@ interface HorizontalProps {
   columnsVisible: ColumnVisibility;
   pagination: PaginationControls;
   reloadArticles: KeyedMutator<SelectionArticles>;
+  extraParams?: Record<string, any>;
 }
 
 export const SplitHorizontal: React.FC<HorizontalProps> = ({
@@ -42,7 +40,40 @@ export const SplitHorizontal: React.FC<HorizontalProps> = ({
   columnsVisible,
   pagination,
   reloadArticles,
+  extraParams = {},
 }) => {
+  const motionStyle = {
+    width: "100%",
+    height: "48%",
+    display: "flex",
+    flexDirection: "column" as const,
+  };
+
+  const selectionArea = (
+    <Box w="100%" h="100%" overflowY="auto" overflowX="hidden">
+      <StudySelectionArea
+        articles={articles}
+        page={page}
+        reloadArticles={reloadArticles}
+        currentPage={pagination.currentPage - 1}
+        totalPages={pagination.quantityOfPages}
+        pageSize={pagination.itensPerPage}
+        extraParams={extraParams}
+      />
+    </Box>
+  );
+
+  const table = (
+    <Box w="100%" h="100%" overflowY="auto" overflowX="hidden">
+      <ArticlesTable
+        articles={articles}
+        layout={layout}
+        columnsVisible={columnsVisible}
+        pagination={pagination}
+      />
+    </Box>
+  );
+
   return (
     <Flex
       w="100%"
@@ -52,105 +83,28 @@ export const SplitHorizontal: React.FC<HorizontalProps> = ({
       justifyContent="space-between"
       overflow="hidden"
     >
-      {isInverted ? (
-        <AnimatePresence mode="wait">
-          <motion.div
-            key="top"
-            variants={horizontalTransitionVariants}
-            initial="initial"
-            animate="animate"
-            exit="exit"
-            style={{ 
-              width: "100%", 
-              height: "48%",
-              display: "flex",
-              flexDirection: "column"
-            }}
-          >
-            <Box w="100%" h="100%" overflowY="auto" overflowX="hidden">
-              <StudySelectionArea
-                articles={articles}
-                page={page}
-                reloadArticles={reloadArticles}
-                currentPage={pagination.currentPage - 1}
-                totalPages={pagination.quantityOfPages}
-                pageSize={pagination.itensPerPage}
-              />
-            </Box>
-          </motion.div>
-          <motion.div
-            key="bottom"
-            variants={horizontalTransitionVariants}
-            initial="initial"
-            animate="animate"
-            exit="exit"
-            style={{ 
-              width: "100%", 
-              height: "48%", 
-              display: "flex",
-              flexDirection: "column"
-            }}
-          >
-            <Box w="100%" h="100%" overflowY="auto" overflowX="hidden">
-              <ArticlesTable
-                articles={articles}
-                layout={layout}
-                columnsVisible={columnsVisible}
-                pagination={pagination}
-              />
-            </Box>
-          </motion.div>
-        </AnimatePresence>
-      ) : (
-        <AnimatePresence mode="wait">
-          <motion.div
-            key="bottom"
-            variants={horizontalTransitionVariants}
-            initial="initial"
-            animate="animate"
-            exit="exit"
-            style={{ 
-              width: "100%", 
-              height: "48%", 
-              display: "flex",
-              flexDirection: "column"
-            }}
-          >
-            <Box w="100%" h="100%" overflowY="auto" overflowX="hidden">
-              <ArticlesTable
-                articles={articles}
-                layout={layout}
-                columnsVisible={columnsVisible}
-                pagination={pagination}
-              />
-            </Box>
-          </motion.div>
-          <motion.div
-            key="top"
-            variants={horizontalTransitionVariants}
-            initial="initial"
-            animate="animate"
-            exit="exit"
-            style={{ 
-              width: "100%", 
-              height: "48%", 
-              display: "flex",
-              flexDirection: "column"
-            }}
-          >
-            <Box w="100%" h="100%" overflowY="auto" overflowX="hidden">
-              <StudySelectionArea
-                articles={articles}
-                page={page}
-                reloadArticles={reloadArticles}
-                currentPage={pagination.currentPage - 1}
-                totalPages={pagination.quantityOfPages}
-                pageSize={pagination.itensPerPage}
-              />
-            </Box>
-          </motion.div>
-        </AnimatePresence>
-      )}
+      <AnimatePresence mode="wait">
+        <motion.div
+          key="first"
+          variants={horizontalTransitionVariants}
+          initial="initial"
+          animate="animate"
+          exit="exit"
+          style={motionStyle}
+        >
+          {isInverted ? selectionArea : table}
+        </motion.div>
+        <motion.div
+          key="second"
+          variants={horizontalTransitionVariants}
+          initial="initial"
+          animate="animate"
+          exit="exit"
+          style={motionStyle}
+        >
+          {isInverted ? table : selectionArea}
+        </motion.div>
+      </AnimatePresence>
     </Flex>
   );
 };

--- a/src/features/review/shared/components/common/layouts/SplitVertical/index.tsx
+++ b/src/features/review/shared/components/common/layouts/SplitVertical/index.tsx
@@ -6,24 +6,20 @@ import { Flex } from "@chakra-ui/react";
 import StudySelectionArea from "../../../structure/StudySelectionArea";
 import ArticlesTable from "../../tables/ArticlesTable";
 
-// Hooks
+// Types
 import ArticleInterface from "../../../../types/ArticleInterface";
-
-// Hooks
 import { ColumnVisibility } from "@features/review/shared/hooks/useVisibilityColumns";
+import type { PageLayout } from "../../../structure/LayoutFactory";
+import { PaginationControls } from "@features/shared/types/pagination";
+import { KeyedMutator } from "swr";
+import { SelectionArticles } from "@features/review/execution-selection/services/useFetchSelectionArticles";
 
-// Animations
 const verticalTransitionVariants = {
   initial: { opacity: 0, x: 5 },
   animate: { opacity: 1, x: 0, transition: { duration: 0.5 } },
   exit: { opacity: 0, x: -5, transition: { duration: 0.5 } },
 };
 
-// Types
-import type { PageLayout } from "../../../structure/LayoutFactory";
-import { PaginationControls } from "@features/shared/types/pagination";
-import { KeyedMutator } from "swr";
-import { SelectionArticles } from "@features/review/execution-selection/services/useFetchSelectionArticles";
 interface VerticalProps {
   isInverted: boolean;
   articles: ArticleInterface[];
@@ -31,6 +27,7 @@ interface VerticalProps {
   columnsVisible: ColumnVisibility;
   pagination: PaginationControls;
   reloadArticles: KeyedMutator<SelectionArticles>;
+  extraParams?: Record<string, any>;
 }
 
 export const SplitVertical: React.FC<VerticalProps> = ({
@@ -40,7 +37,28 @@ export const SplitVertical: React.FC<VerticalProps> = ({
   columnsVisible,
   pagination,
   reloadArticles,
+  extraParams = {},
 }) => {
+  const selectionArea = (
+    <StudySelectionArea
+      articles={articles}
+      page={page}
+      reloadArticles={reloadArticles}
+      currentPage={pagination.currentPage - 1}
+      totalPages={pagination.quantityOfPages}
+      pageSize={pagination.itensPerPage}
+      extraParams={extraParams}
+    />
+  );
+
+  const table = (
+    <ArticlesTable
+      articles={articles}
+      columnsVisible={columnsVisible}
+      pagination={pagination}
+    />
+  );
+
   return (
     <Flex
       w="100%"
@@ -49,75 +67,34 @@ export const SplitVertical: React.FC<VerticalProps> = ({
       justifyContent="space-between"
       pr=".5rem"
     >
-      {isInverted ? (
-        <AnimatePresence mode="wait">
-          <motion.div
-            key="top"
-            variants={verticalTransitionVariants}
-            initial="initial"
-            animate="animate"
-            exit="exit"
-            style={{ minWidth: "35%", maxHeight: "100%" }}
-          >
-            <StudySelectionArea
-              articles={articles}
-              page={page}
-              reloadArticles={reloadArticles}
-              currentPage={pagination.currentPage - 1}
-              totalPages={pagination.quantityOfPages}
-              pageSize={pagination.itensPerPage}
-            />
-          </motion.div>
-          <motion.div
-            key="bottom"
-            variants={verticalTransitionVariants}
-            initial="initial"
-            animate="animate"
-            exit="exit"
-            style={{ maxWidth: "65%", maxHeight: "100%" }}
-          >
-            <ArticlesTable
-              articles={articles}
-              columnsVisible={columnsVisible}
-              pagination={pagination}
-            />
-          </motion.div>
-        </AnimatePresence>
-      ) : (
-        <AnimatePresence mode="wait">
-          <motion.div
-            key="bottom"
-            variants={verticalTransitionVariants}
-            initial="initial"
-            animate="animate"
-            exit="exit"
-            style={{ maxWidth: "65%", maxHeight: "100%" }}
-          >
-            <ArticlesTable
-              articles={articles}
-              columnsVisible={columnsVisible}
-              pagination={pagination}
-            />
-          </motion.div>
-          <motion.div
-            key="top"
-            variants={verticalTransitionVariants}
-            initial="initial"
-            animate="animate"
-            exit="exit"
-            style={{ minWidth: "35%", maxHeight: "100%" }}
-          >
-            <StudySelectionArea
-              articles={articles}
-              page={page}
-              reloadArticles={reloadArticles}
-              currentPage={pagination.currentPage - 1}
-              totalPages={pagination.quantityOfPages}
-              pageSize={pagination.itensPerPage}
-            />
-          </motion.div>
-        </AnimatePresence>
-      )}
+      <AnimatePresence mode="wait">
+        <motion.div
+          key="first"
+          variants={verticalTransitionVariants}
+          initial="initial"
+          animate="animate"
+          exit="exit"
+          style={isInverted
+            ? { minWidth: "35%", maxHeight: "100%" }
+            : { maxWidth: "65%", maxHeight: "100%" }
+          }
+        >
+          {isInverted ? selectionArea : table}
+        </motion.div>
+        <motion.div
+          key="second"
+          variants={verticalTransitionVariants}
+          initial="initial"
+          animate="animate"
+          exit="exit"
+          style={isInverted
+            ? { maxWidth: "65%", maxHeight: "100%" }
+            : { minWidth: "35%", maxHeight: "100%" }
+          }
+        >
+          {isInverted ? table : selectionArea}
+        </motion.div>
+      </AnimatePresence>
     </Flex>
   );
 };

--- a/src/features/review/shared/components/common/layouts/SplitVertical/index.tsx
+++ b/src/features/review/shared/components/common/layouts/SplitVertical/index.tsx
@@ -63,6 +63,9 @@ export const SplitVertical: React.FC<VerticalProps> = ({
               articles={articles}
               page={page}
               reloadArticles={reloadArticles}
+              currentPage={pagination.currentPage - 1}
+              totalPages={pagination.quantityOfPages}
+              pageSize={pagination.itensPerPage}
             />
           </motion.div>
           <motion.div
@@ -108,6 +111,9 @@ export const SplitVertical: React.FC<VerticalProps> = ({
               articles={articles}
               page={page}
               reloadArticles={reloadArticles}
+              currentPage={pagination.currentPage - 1}
+              totalPages={pagination.quantityOfPages}
+              pageSize={pagination.itensPerPage}
             />
           </motion.div>
         </AnimatePresence>

--- a/src/features/review/shared/components/structure/LayoutFactory/index.tsx
+++ b/src/features/review/shared/components/structure/LayoutFactory/index.tsx
@@ -29,6 +29,7 @@ interface LayoutFactoryProps {
   columnsVisible: ColumnVisibility;
   pagination: PaginationControls;
   reloadArticles: KeyedMutator<SelectionArticles>;
+  extraParams?: Record<string, any>;
 }
 
 export default function LayoutFactory({
@@ -40,10 +41,10 @@ export default function LayoutFactory({
   columnsVisible,
   pagination,
   reloadArticles,
+  extraParams = {},
 }: LayoutFactoryProps) {
   const handleRowClick = () => {
-      handleChangeLayout("vertical");
-    
+    handleChangeLayout("vertical");
   };
 
   const layoutMap: Record<ViewModel, React.ReactNode> = {
@@ -63,6 +64,7 @@ export default function LayoutFactory({
         columnsVisible={columnsVisible}
         pagination={pagination}
         reloadArticles={reloadArticles}
+        extraParams={extraParams}
       />
     ),
     "vertical-invert": (
@@ -73,6 +75,7 @@ export default function LayoutFactory({
         columnsVisible={columnsVisible}
         pagination={pagination}
         reloadArticles={reloadArticles}
+        extraParams={extraParams}
       />
     ),
     horizontal: (
@@ -84,6 +87,7 @@ export default function LayoutFactory({
         columnsVisible={columnsVisible}
         pagination={pagination}
         reloadArticles={reloadArticles}
+        extraParams={extraParams}
       />
     ),
     "horizontal-invert": (
@@ -95,6 +99,7 @@ export default function LayoutFactory({
         columnsVisible={columnsVisible}
         pagination={pagination}
         reloadArticles={reloadArticles}
+        extraParams={extraParams}
       />
     ),
     article: (

--- a/src/features/review/shared/components/structure/StudySelectionArea/index.tsx
+++ b/src/features/review/shared/components/structure/StudySelectionArea/index.tsx
@@ -1,5 +1,5 @@
 // External library
-import { useContext } from "react";
+import { useContext, useState } from "react";
 import { Box, Flex } from "@chakra-ui/react";
 
 // Components
@@ -7,6 +7,9 @@ import ButtonsForSelection from "../../common/buttons/ButtonsForSelection";
 
 // Context
 import StudyContext from "@features/review/shared/context/StudiesContext";
+
+// Infra
+import Axios from "../../../../../../infrastructure/http/axiosClient";
 
 // Types
 import type { PageLayout } from "../LayoutFactory";
@@ -20,12 +23,18 @@ interface StudySelectionAreaProps {
   articles: ArticleInterface[] | StudyInterface[];
   page: PageLayout;
   reloadArticles: KeyedMutator<SelectionArticles>;
+  currentPage: number;
+  totalPages: number;
+  pageSize: number;
 }
 
 export default function StudySelectionArea({
   articles,
   page,
   reloadArticles,
+  currentPage,
+  totalPages,
+  pageSize,
 }: StudySelectionAreaProps) {
   const studiesContext = useContext(StudyContext);
 
@@ -34,9 +43,43 @@ export default function StudySelectionArea({
 
   const { selectedArticleReview, setSelectedArticleReview } = studiesContext;
 
-  if (!articles || articles.length === 0) return null;
+  const [navPage, setNavPage] = useState(currentPage);
+  const [navArticles, setNavArticles] = useState<ArticleInterface[] | null>(null);
 
-  const typedArticles = articles.filter(
+  const id = localStorage.getItem("systematicReviewId");
+
+  const fetchPageSilently = async (targetPage: number): Promise<ArticleInterface[]> => {
+    const response = await Axios.get<SelectionArticles>(
+      `systematic-study/${id}/study-review/search`,
+      { params: { page: targetPage, size: pageSize } }
+    );
+    return response.data.studyReviews.filter(
+      (art): art is ArticleInterface => "studyReviewId" in art
+    );
+  };
+
+  const onFetchNextPage = async (): Promise<ArticleInterface[]> => {
+    const next = navPage + 1;
+    const fetched = await fetchPageSilently(next);
+    setNavPage(next);
+    setNavArticles(fetched);
+    return fetched;
+  };
+
+  const onFetchPrevPage = async (): Promise<ArticleInterface[]> => {
+    const prev = navPage - 1;
+    const fetched = await fetchPageSilently(prev);
+    setNavPage(prev);
+    setNavArticles(fetched);
+    return fetched;
+  };
+
+  const activeArticles: ArticleInterface[] | StudyInterface[] =
+    navArticles !== null ? navArticles : articles;
+
+  if (!activeArticles || activeArticles.length === 0) return null;
+
+  const typedArticles = activeArticles.filter(
     (art): art is ArticleInterface => "studyReviewId" in art
   );
 
@@ -46,8 +89,8 @@ export default function StudySelectionArea({
 
   const studyIndex = findSelectedArticle >= 0 ? findSelectedArticle : 0;
 
-  if (studyIndex == 0) {
-    setSelectedArticleReview(typedArticles[studyIndex].studyReviewId);
+  if (studyIndex === 0 && typedArticles[0]) {
+    setSelectedArticleReview(typedArticles[0].studyReviewId);
   }
 
   return (
@@ -64,17 +107,18 @@ export default function StudySelectionArea({
       <Flex alignItems="center" justifyContent="center" w="100%" maxW="100%">
         <ButtonsForSelection
           page={page}
-          articles={articles}
+          articles={activeArticles}
           articleIndex={studyIndex}
           setSelectedArticleReview={setSelectedArticleReview}
           reloadArticles={reloadArticles}
+          isLastPage={navPage >= totalPages - 1}
+          isFirstPage={navPage <= 0}
+          onFetchNextPage={onFetchNextPage}
+          onFetchPrevPage={onFetchPrevPage}
         />
       </Flex>
       <Box w="100%" h="80%">
-        <StudyDataFiel
-          studyData={articles?.[studyIndex] as StudyInterface}
-          page={page}
-        />
+        <StudyDataFiel studyData={activeArticles?.[studyIndex] as StudyInterface} page={page} />
       </Box>
     </Flex>
   );

--- a/src/features/review/shared/components/structure/StudySelectionArea/index.tsx
+++ b/src/features/review/shared/components/structure/StudySelectionArea/index.tsx
@@ -1,5 +1,5 @@
 // External library
-import { useContext, useState } from "react";
+import { useContext, useState, useEffect } from "react";
 import { Box, Flex } from "@chakra-ui/react";
 
 // Components
@@ -26,6 +26,7 @@ interface StudySelectionAreaProps {
   currentPage: number;
   totalPages: number;
   pageSize: number;
+  extraParams?: Record<string, any>;
 }
 
 export default function StudySelectionArea({
@@ -35,6 +36,7 @@ export default function StudySelectionArea({
   currentPage,
   totalPages,
   pageSize,
+  extraParams = {},
 }: StudySelectionAreaProps) {
   const studiesContext = useContext(StudyContext);
 
@@ -48,30 +50,75 @@ export default function StudySelectionArea({
 
   const id = localStorage.getItem("systematicReviewId");
 
+  const firstArticleId = (articles[0] as ArticleInterface)?.studyReviewId ?? null;
+
+  useEffect(() => {
+    setNavPage(currentPage);
+    setNavArticles(null);
+  }, [currentPage]);
+
+  useEffect(() => {
+    setNavPage(currentPage);
+    setNavArticles(null);
+  }, [firstArticleId]);
+
   const fetchPageSilently = async (targetPage: number): Promise<ArticleInterface[]> => {
-    const response = await Axios.get<SelectionArticles>(
-      `systematic-study/${id}/study-review/search`,
-      { params: { page: targetPage, size: pageSize } }
-    );
-    return response.data.studyReviews.filter(
-      (art): art is ArticleInterface => "studyReviewId" in art
-    );
+    try {
+      const response = await Axios.get<SelectionArticles>(
+        `systematic-study/${id}/study-review/search`,
+        {
+          params: {
+            page: targetPage,
+            size: pageSize,
+            ...extraParams,
+          },
+        }
+      );
+      return response.data.studyReviews.filter(
+        (art): art is ArticleInterface => "studyReviewId" in art
+      );
+    } catch (error) {
+      console.error(`Failed to fetch page ${targetPage}:`, error);
+      return [];
+    }
   };
 
   const onFetchNextPage = async (): Promise<ArticleInterface[]> => {
     const next = navPage + 1;
     const fetched = await fetchPageSilently(next);
-    setNavPage(next);
-    setNavArticles(fetched);
+    if (fetched.length > 0) {
+      setNavPage(next);
+      setNavArticles(fetched);
+    }
     return fetched;
   };
 
   const onFetchPrevPage = async (): Promise<ArticleInterface[]> => {
     const prev = navPage - 1;
     const fetched = await fetchPageSilently(prev);
-    setNavPage(prev);
-    setNavArticles(fetched);
+    if (fetched.length > 0) {
+      setNavPage(prev);
+      setNavArticles(fetched);
+    }
     return fetched;
+  };
+
+  const onWrapToLast = async (): Promise<ArticleInterface[]> => {
+    const lastPage = totalPages - 1;
+    const fetched = await fetchPageSilently(lastPage);
+    if (fetched.length > 0) {
+      setNavPage(lastPage);
+      setNavArticles(fetched);
+    }
+    return fetched;
+  };
+
+  const onWrapToFirst = (): ArticleInterface[] => {
+    setNavPage(currentPage);
+    setNavArticles(null);
+    return articles.filter(
+      (art): art is ArticleInterface => "studyReviewId" in art
+    );
   };
 
   const activeArticles: ArticleInterface[] | StudyInterface[] =
@@ -89,9 +136,11 @@ export default function StudySelectionArea({
 
   const studyIndex = findSelectedArticle >= 0 ? findSelectedArticle : 0;
 
-  if (studyIndex === 0 && typedArticles[0]) {
-    setSelectedArticleReview(typedArticles[0].studyReviewId);
-  }
+  useEffect(() => {
+    if (studyIndex === 0 && typedArticles[0]) {
+      setSelectedArticleReview(typedArticles[0].studyReviewId);
+    }
+  }, [typedArticles[0]?.studyReviewId]);
 
   return (
     <Flex
@@ -115,6 +164,8 @@ export default function StudySelectionArea({
           isFirstPage={navPage <= 0}
           onFetchNextPage={onFetchNextPage}
           onFetchPrevPage={onFetchPrevPage}
+          onWrapToLast={onWrapToLast}
+          onWrapToFirst={onWrapToFirst}
         />
       </Flex>
       <Box w="100%" h="80%">


### PR DESCRIPTION
## Navegação entre artigos considera todas as páginas na tela meio a meio
- Anteriormente, ao navegar entre artigos na visualização de resumo (tela meio a meio), a lógica de próximo/anterior considerava apenas os artigos da página atual da tabela. Ao chegar no último artigo, a navegação voltava ao início da mesma página.
- Com essa mudança, ao atingir o limite da página atual, o sistema realiza um fetch silencioso da página seguinte (ou anterior) sem alterar ou re-renderizar a tabela principal. A navegação passa a ser contínua considerando todos os artigos do estudo, tanto na página de Seleção quanto na de Extração.