### PR TITLE
fix(identification): populate comment textarea with existing comment on edit modal

### DIFF
--- a/src/features/review/execution-identification/pages/Identification/subcomponents/modals/IdentificationModal/index.tsx
+++ b/src/features/review/execution-identification/pages/Identification/subcomponents/modals/IdentificationModal/index.tsx
@@ -90,6 +90,7 @@ function IdentificationModal({
           const selectedSession = response.data.searchSessions.find((session : any) => session.id === sessionId);
           if(selectedSession) {
             setSearchString(selectedSession.searchString);
+            setComment(selectedSession.additionalInfo);
           }
         } catch(error) {
           const toast = useToaster();
@@ -169,6 +170,7 @@ function IdentificationModal({
             <FormLabel>Comments</FormLabel>
             <Textarea
               placeholder="Add comments"
+              value={comment}
               onChange={(event) => setComment(event.target.value)}
             />
           </FormControl>


### PR DESCRIPTION
## Improvements
- Pre-fill the comment textarea when opening the edit modal.

### Before 
<img width="1919" height="910" alt="Captura de tela 2026-03-25 163851" src="https://github.com/user-attachments/assets/ec22b85b-24d8-4a8f-b90e-b2fb5411cd4b" />

### After 
<img width="1918" height="910" alt="Captura de tela 2026-03-25 164122" src="https://github.com/user-attachments/assets/2a4cd427-f19e-41eb-bfef-2e0df3d50609" />