### PR TITLE
GM-fix-identification-update-session

### DIFF
--- a/src/features/review/execution-identification/pages/Identification/subcomponents/modals/IdentificationModal/index.tsx
+++ b/src/features/review/execution-identification/pages/Identification/subcomponents/modals/IdentificationModal/index.tsx
@@ -26,6 +26,7 @@ import { DeleteIcon } from "@chakra-ui/icons";
 import { KeyedMutator } from "swr";
 import StudyContext from "@features/review/shared/context/StudiesContext";
 import useHandleExportedFiles from "@features/review/execution-identification/services/useHandleExportedFiles";
+import useUpdateSession from "@features/review/execution-identification/services/useUpdateSession";
 import DragAndDrop from "@components/common/inputs/DragAndDropInput";
 import Axios from "../../../../../../../../infrastructure/http/axiosClient";
 
@@ -78,6 +79,15 @@ function IdentificationModal({
     comment,
   });
 
+  const { updateSession } = useUpdateSession({ 
+    sessionId, 
+    mutate, 
+    searchString, 
+    comment, 
+    type
+  });
+
+
   useEffect(() => {
     const fetchSession = async () => {  
       setSource(type);
@@ -118,7 +128,11 @@ function IdentificationModal({
       return;
     }
 
-    sendFilesToServer();
+    if(action === "create") {
+      sendFilesToServer();
+    } else {
+      updateSession();
+    }
     reloadArticles("Selection");
     show(false);
     onClose();

--- a/src/features/review/execution-identification/services/useUpdateSession.tsx
+++ b/src/features/review/execution-identification/services/useUpdateSession.tsx
@@ -1,0 +1,60 @@
+import { KeyedMutator } from "swr";
+import Axios from "../../../../infrastructure/http/axiosClient";
+import useToaster from "@components/feedback/Toaster";
+
+interface UpdateSessionProps {
+    sessionId?: string;    
+    mutate: KeyedMutator<
+    {
+        id: string;
+        systematicStudyd: string;
+        userId: string;
+        searchString: string;
+        additionalInfo: string;
+        timestamp: string;
+        source: string;
+        numberOfRelatedStudies: number;
+    }[]
+    >;
+    searchString: string;
+    comment: string;
+    type: string;
+}
+
+export default function useUpdateSession({
+  sessionId,
+  mutate,
+  searchString,
+  comment,
+  type
+}: UpdateSessionProps) {
+    const toast = useToaster();
+
+    const updateSession = async () => {
+        try {
+            const id = localStorage.getItem("systematicReviewId");
+            const url = `systematic-study/${id}/search-session/${sessionId}`;
+        
+            const response = await Axios.put(url, 
+                {
+                    "searchString": searchString,
+                    "additionalInfo": comment,
+                    "source": type
+                }
+            );
+            if(!response) throw new Error();
+            mutate();
+            toast({
+            title: "Session updated successfully",
+            status: "success",
+            });
+        } catch(error) {
+            toast({
+            title: "Error updating session",
+            status: "error",
+            });
+        }
+    };
+
+    return { updateSession };
+}


### PR DESCRIPTION
## Summary
This PR fixes the session update flow by ensuring that editing an existing session properly triggers a PUT request instead of a POST request. 

Previously, clicking the update incorrectly triggered the create flow, preventing the existing session from being properly updated. 

## Changes 
### Fixes 
- Adds `useUpdateSession` hook to handle session update logic 
- Calls the `PUT /systematic-study/${id}/search-session/${sessionId}` endpoint when editing 
- Adds conditional logic to distinguish between create and update actions 
- Triggers `mutate()` after a successful update to refresh the session list 
- Displays success or error toast feedback

### Creating a new session 
<img width="1916" height="907" alt="Captura de tela 2026-03-29 235516" src="https://github.com/user-attachments/assets/0469eb47-dbc1-4048-90b4-7eaf2faa535a" /> 

### Editing it 
<img width="1803" height="861" alt="Captura de tela 2026-03-29 235852" src="https://github.com/user-attachments/assets/95dd9ff3-7906-42fb-8623-c04271679a6e" /> 

### Successful update 
<img width="1809" height="858" alt="Captura de tela 2026-03-30 000015" src="https://github.com/user-attachments/assets/4c27b324-7b35-4cdf-a4fd-04f1f0f572e7" /> 

### After update 
<img width="1812" height="856" alt="Captura de tela 2026-03-30 000057" src="https://github.com/user-attachments/assets/28956827-07bd-4c12-969f-9311e607bb19" />