### PR TITLE
feat(selection): display ic/ec codes instead of full text

### DIFF
--- a/src/features/review/shared/components/common/menu/ComboBox/index.tsx
+++ b/src/features/review/shared/components/common/menu/ComboBox/index.tsx
@@ -142,7 +142,7 @@ export default function ComboBox({
                       fontWeight={isHighlighted ? "bold" : "normal"}
                       color={isHighlighted ? "black" : "inherit"}
                     >
-                      {option.text}
+                      {`IC-${(index + 1).toString().padStart(2, '0')}`}
                     </Text>
                   </Tooltip>
                 </Checkbox>
@@ -189,7 +189,7 @@ export default function ComboBox({
                       fontWeight={isHighlighted ? "bold" : "normal"}
                       color={isHighlighted ? "black" : "inherit"}
                     >
-                      {option.text}
+                      {`EC-${(index + 1).toString().padStart(2, '0')}`}
                     </Text>
                   </Tooltip>
                 </Checkbox>


### PR DESCRIPTION
### Checkbox IC/EC, deve aparecer apenas o código e o texto aparecer como um tooltip

- Na tela de seleção (Execution -> Selection), ao selecionar um artigo e abrir o menu de Include ou Exclude de critérios, a lista era exibida com a descrição completa. Este PR faz com que apareça apenas o código do critério no checkbox, exibindo a descrição completa como um tooltip.


### Local da Alteração

<img width="204" height="599" alt="image" src="https://github.com/user-attachments/assets/ca94c904-66c4-4b69-ba0a-420b216bc79c" />

### Antes

<img width="1899" height="928" alt="image" src="https://github.com/user-attachments/assets/304b260a-3052-4fcc-ba25-88d5f90836a1" />

### Depois

<img width="1899" height="928" alt="image" src="https://github.com/user-attachments/assets/64885983-354d-4732-859e-c087a906612d" />

### Tooltip com o texto

<img width="1912" height="941" alt="image" src="https://github.com/user-attachments/assets/550f6e4d-94f1-419e-a6a0-924e83d4bed2" />

