### PR TITLE
style(summarization) [BO-43]: standardize layout and relocate download section in sidebar

### DIFF
--- a/src/features/review/summarization-download/pages/download/index.tsx
+++ b/src/features/review/summarization-download/pages/download/index.tsx
@@ -6,6 +6,9 @@ import Header from "@components/structure/Header/Header";
 import FlexLayout from "@components/structure/Flex/Flex";
 import CardDefault from "@components/common/cards";
 
+// Buttons
+import { DownloadProtocolMenu } from "@features/review/summarization-graphics/components/buttons/DownloadProtocolButton";
+
 export default function Download() {
   return (
     <FlexLayout navigationType="Accordion">
@@ -16,10 +19,10 @@ export default function Download() {
         borderRadius="1rem"
         withShadow={false}
       >
-        <Box w="100%" px="1rem" py="1rem" minH="400px" display="flex" justifyContent="center" alignItems="center">
-          {/* Deixei esse espaço pronto e centralizado! 
-            O seu amigo só vai precisar apagar este comentário e colocar o botão dele aqui. 
-          */}
+        <Box
+          w="100%" px="1rem" py="1rem" minH="calc(100vh - 130px)" display="flex" justifyContent="center" alignItems="center"
+        >
+          <DownloadProtocolMenu />
         </Box>
       </CardDefault>
     </FlexLayout>

--- a/src/features/review/summarization-graphics/components/menus/SectionMenu/index.tsx
+++ b/src/features/review/summarization-graphics/components/menus/SectionMenu/index.tsx
@@ -31,7 +31,6 @@ const sections: Section[] = [
   { label: "Studies Funnel", value: "Studies Funnel" },
   { label: "Included Studies", value: "Included Studies" },
   { label: "Form Questions", value: "Form Questions" },
-   { label: "Download Protocolo", value: "Protocol" }
 ];
 
 export default function SectionMenu({ onSelect, selected }: MenuProps) {

--- a/src/features/review/summarization-graphics/pages/Graphics/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/index.tsx
@@ -1,6 +1,7 @@
-import { Box, Flex, Text } from "@chakra-ui/react";
+import { Flex, Text } from "@chakra-ui/react";
 import Header from "@components/structure/Header/Header";
 import FlexLayout from "@components/structure/Flex/Flex";
+import CardDefault from "@components/common/cards";
 import ChartsRenderer from "./subcomponents/ChartRenderer";
 import SelectMenu from "../../components/menus/SelectMenu";
 import { useGraphicsState } from "../../hooks/useGraphicsState";
@@ -25,71 +26,71 @@ export default function Graphics() {
 
   return (
     <FlexLayout navigationType="Accordion">
-    <Box w="100%" ml="-0.5rem" pl="0" pr="1rem" py=".75rem" h="fit-content">
-        <Flex justifyContent={"space-between"} w={"100%"}>
-          <Flex w="100%" h="2.5rem" alignItems="center" mb="1rem">
-            <Header text="Graphics" />
-          </Flex>
-            <Flex flexDirection="column" gap="0.5rem">
-              <SectionMenu onSelect={handleSectionChange} selected={section} />
-              {!(section === "Studies Funnel" || section === "Form Questions" || section === "Protocol") && 
-              (
-                <SelectMenu
-                  options={currentAllowedTypes}
-                  selected={type}
-                  onSelect={setType}
-                  placeholder="Choose Layout"
-                />
-              )}
-              {section === "Form Questions" && (
-                <SelectMenu
-                  options={allQuestions.filter((q) => q.questionId !== null)}
-                  selected={allQuestions.find(
-                    (q) => q.questionId === selectedQuestionId
-                  )}
-                  onSelect={(q) =>
-                    setSelectedQuestionId(q.questionId ?? undefined)
-                  }
-                  getLabel={(q) => q.code}
-                  getKey={(q) => q.questionId ?? q.code}
-                  placeholder="Choose Question"
-                />
-              )}
-            </Flex>
+      <Flex justifyContent="space-between" alignItems="flex-start" w="100%" mb="1rem">
         
+        <Flex flexDirection="column" gap="0.75rem">
+          <Header text="Graphics" />
+
+          {filtersBySection[section]?.length > 0 && (
+            <Flex flexDirection="column" gap="0.5rem">
+              <Text fontWeight="semibold" fontSize="lg" color="#263C56">
+                Filters Area
+              </Text>
+              <FiltersMenu
+                availableFilters={filtersBySection[section]}
+                filters={filters}
+                setFilters={setFilters}
+              />
+            </Flex>
+          )}
         </Flex>
-        {/* Filters Area */}
-        {filtersBySection[section]?.length > 0 && (
-          <Box mb="1rem">
-            <Text
-              fontWeight="semibold"
-              fontSize="lg"
-              color="#263C56"
-              mb="0.5rem"
-            >
-              Filters Area
-            </Text>
-            <FiltersMenu
-              availableFilters={filtersBySection[section]}
-              filters={filters}
-              setFilters={setFilters}
+
+        <Flex flexDirection="column" gap="0.5rem" mt="0.75rem">
+          <SectionMenu onSelect={handleSectionChange} selected={section} />
+          {!(
+            section === "Studies Funnel" ||
+            section === "Form Questions" ||
+            section === "Protocol"
+          ) && (
+            <SelectMenu
+              options={currentAllowedTypes}
+              selected={type}
+              onSelect={setType}
+              placeholder="Choose Layout"
             />
-          </Box>
-        )}
+          )}
+          {section === "Form Questions" && (
+            <SelectMenu
+              options={allQuestions.filter((q) => q.questionId !== null)}
+              selected={allQuestions.find(
+                (q) => q.questionId === selectedQuestionId
+              )}
+              onSelect={(q) =>
+                setSelectedQuestionId(q.questionId ?? undefined)
+              }
+              getLabel={(q) => q.code}
+              getKey={(q) => q.questionId ?? q.code}
+              placeholder="Choose Question"
+            />
+          )}
+        </Flex>
+      </Flex>
 
-        {/* Charts */}
-            <ExportProvider>
-                 <ChartsRenderer
-          key={section + type + JSON.stringify(filters) + selectedQuestionId}
-          section={section}
-          type={type}
-          filters={filters}
-          selectedQuestionId={selectedQuestionId}
-        />
-
-            </ExportProvider>
-     
-      </Box>
+      <CardDefault
+        backgroundColor="#fff"
+        borderRadius="1rem"
+        withShadow={false}
+      >
+        <ExportProvider>
+          <ChartsRenderer
+            key={section + type + JSON.stringify(filters) + selectedQuestionId}
+            section={section}
+            type={type}
+            filters={filters}
+            selectedQuestionId={selectedQuestionId}
+          />
+        </ExportProvider>
+      </CardDefault>
     </FlexLayout>
   );
 }

--- a/src/features/review/summarization-graphics/pages/Graphics/styles.ts
+++ b/src/features/review/summarization-graphics/pages/Graphics/styles.ts
@@ -12,15 +12,12 @@ export const conteiner = {
 
 export const graphicsconteiner = {
   maxW: "100%",
-  mt:"5px",
-  borderWidth: "1px",
+  mt: "5px",
+  borderWidth: "0px",
   borderRadius: "lg",
   display: "flex",
-  flexWrap: "wrap",
-  gap: "2em",                 
-  justifyContent: "center",   
-  alignItems:"center",
-  bg: 'white',
+  flexDirection: "column",
+  bg: "white",
 };
 
 export const barchartBox = {

--- a/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/ProtocolRenderer/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/ProtocolRenderer/index.tsx
@@ -1,5 +1,23 @@
-import { DownloadProtocolMenu } from "@features/review/summarization-graphics/components/buttons/DownloadProtocolButton";
+import { Box } from "@chakra-ui/react";
+import Header from "@components/structure/Header/Header";
+import FlexLayout from "@components/structure/Flex/Flex";
+import CardDefault from "@components/common/cards";
+import ProtocolRenderer from "@features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/ProtocolRenderer";
 
-export default function ProtocolRenderer() {
-  return <DownloadProtocolMenu />;
+export default function Download() 
+{
+  return (
+    <FlexLayout navigationType="Accordion">
+      <Header text="Download" />
+      <CardDefault
+        backgroundColor="#ffffff"
+        borderRadius="1rem"
+        withShadow={false}
+      >
+        <Box w="200%" px="1rem" py="1rem" minH="400px" display="flex" justifyContent="center" alignItems="center">
+          <ProtocolRenderer />
+        </Box>
+      </CardDefault>
+    </FlexLayout>
+  );
 }

--- a/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/index.tsx
@@ -10,7 +10,6 @@ import SearchSourcesRenderer from "./SearchSourcesRenderer";
 import IncludedStudiesRenderer from "./IncludedStudiesRenderer";
 import CriteriaRenderer from "./CriteriaRenderer";
 import StudiesFunnelRenderer from "./StudiesFunnelRenderer";
-import ProtocolRenderer from "./ProtocolRenderer";
 import DownloadChartsButton from "@features/review/summarization-graphics/components/buttons/DownloadChatsButton";
 import FormQuestionsRenderer from "./FormQuestionsRenderer";
 import { downloadCSV } from "@features/review/summarization-graphics/components/export/ExportCsv";
@@ -149,62 +148,72 @@ export default function ChartsRenderer({
       />
     ),
     "Studies Funnel": () => <StudiesFunnelRenderer chartId={chartId} />,
-    Protocol: () => <ProtocolRenderer />,
   };
 
   const Renderer = rendererMap[section];
   if (!Renderer) return <Box>Seção não encontrada</Box>;
 
-  return (
+return (
+  <Box
+    sx={{
+      ...graphicsconteiner,
+      minHeight: "calc(100vh - 210px)",
+      justifyContent: "space-between",
+    }}
+  >
     <Box
-      pt={"1rem"}
-      sx={{
-        ...graphicsconteiner,
-        p:
-          section === "Included Studies" ||
-          (section === "Search Sources" && type === "Table")
-            ? undefined
-            : "2rem",
-        boxShadow: "md",
-      }}
+      display="flex"
+      flexWrap="wrap"
+      gap="2em"
+      justifyContent="center"
+      alignItems="center"
+      p={
+        section === "Included Studies" ||
+        (section === "Search Sources" && type === "Table")
+          ? "0"
+          : "2rem"
+      }
+      pt="1rem"
     >
       <Renderer
         filteredStudies={filteredStudies}
         type={type}
         onCsvData={handleCsvData}
       />
-
-      {section !== "Studies Funnel" && section !== "Protocol" && (
-        <Flex w="100%" justifyContent="flex-end" p="1rem">
-          <DownloadChartsButton
-            selector={`#${chartId}`}
-            fileName={section}
-            onDownloadCsv={() => {
-              if (section === "Form Questions") {
-                downloadCSV(
-                  "questions",
-                  buildQuestionsCsv(
-                    extractionAnswers,
-                    filteredStudies as ArticleInterface[],
-                    selectedQuestionId
-                  )
-                );
-              } else {
-                downloadCSV(
-                  section,
-                  getCsvData(
-                    section,
-                    filteredStudies,
-                    type,
-                    filteredStageIds,
-                    studiesByCriteria
-                  )
-                );
-              }
-            }}
-          />
-        </Flex>
-      )}
     </Box>
-  );
+
+    {section !== "Studies Funnel" && (
+      <Flex w="100%" justifyContent="flex-end" p="1rem">
+        <DownloadChartsButton
+          selector={`#${chartId}`}
+          fileName={section}
+          onDownloadCsv={() => {
+            if (section === "Form Questions") 
+              {
+              downloadCSV(
+                "questions",
+                buildQuestionsCsv(
+                  extractionAnswers,
+                  filteredStudies as ArticleInterface[],
+                  selectedQuestionId
+                )
+              );
+            } else {
+              downloadCSV(
+                section,
+                getCsvData(
+                  section,
+                  filteredStudies,
+                  type,
+                  filteredStageIds,
+                  studiesByCriteria
+                )
+              );
+            }
+          }}
+        />
+      </Flex>
+    )}
+  </Box>
+);
 }


### PR DESCRIPTION
**Padronizar a estilização da área de Summarization com o restante da aplicação e organizar o fluxo de exportação do protocolo.**

Este PR foca em alinhar a experiência visual da seção de sumários e gráficos aos padrões de design do sistema. Foi realizado o ajuste no alinhamento dos componentes internos para garantir consistência com o menu lateral e a estrutura de cards da aplicação. Além disso, a funcionalidade de download do protocolo foi movida para uma seção exclusiva no menu lateral, Download.

**ANTES:**
<img width="1915" height="944" alt="image" src="https://github.com/user-attachments/assets/0e70ea4e-5c08-4ed0-8adb-abe3587b4961" />

**DEPOIS:** 
<img width="1919" height="952" alt="image" src="https://github.com/user-attachments/assets/a70d8da1-1c49-42f0-98ac-ff70730b73fa" />

**SEÇÃO DOWNLOAD**
<img width="1920" height="952" alt="image" src="https://github.com/user-attachments/assets/c3a9f1e3-4576-486c-a399-136bf9293af1" />
