### PR TITLE
style(sources): maintain original casing for database names

### DIFF
--- a/src/features/review/planning-protocol/components/common/inputs/selection/AddSelectionTable/index.tsx
+++ b/src/features/review/planning-protocol/components/common/inputs/selection/AddSelectionTable/index.tsx
@@ -29,9 +29,10 @@ export default function AddSelectTable({
 
   const formattedOptions = options.map((opt) => capitalize(opt.toLowerCase()));
 
-  const formatSelectedValues = selectedValues.map((value) =>
-    capitalize(value.toLowerCase())
-  );
+const formatSelectedValues = selectedValues.map((val) => {
+  const originalOption = options.find((opt) => opt.toLowerCase() === val.toLowerCase());
+  return originalOption || val;
+});
 
   return (
     <FormControl sx={conteiner} alignContent={"center"}>


### PR DESCRIPTION
### Databases and Information Source não mantém caixa-alta nos nomes das bases de dados

- Na tela de Sources (Planning -> Sources), ao selecionar um banco de dados, o nome aparece normal, mas quando a base selecionada vai para a tabela, o nome fica formatado errado.

### Local da Alteração
<img width="206" height="903" alt="image" src="https://github.com/user-attachments/assets/0535619b-70cf-4a92-8053-aa70242bedd3" />

### Antes
<img width="1719" height="848" alt="image" src="https://github.com/user-attachments/assets/f863a0db-b05f-49d9-a464-2999a292b51a" />



### Depois
<img width="1721" height="849" alt="image" src="https://github.com/user-attachments/assets/546d43b4-53bc-4077-9502-06e889ecf261" />
