### PR TITLE
style(research): improve secundary questions layout space

### DIFF
--- a/src/features/review/planning-protocol/components/common/tables/InfosTable/styles.ts
+++ b/src/features/review/planning-protocol/components/common/tables/InfosTable/styles.ts
@@ -1,7 +1,7 @@
 export const tbConteiner = {
   border: "solid #263C56 1px",
   w: "60vw",
-  h: "120px",
+  h: "400px",
   overflowY: "auto",
   borderRadius: "6px"
 };


### PR DESCRIPTION
### Secondary Questions de Research Questions, deve ocupar melhor o espaço disponível

- Na tela de Research (Planning -> Research), a tabela de Secundary Questions ocupava pouco espaço na página.

### Local da Alteração
<img width="207" height="914" alt="image" src="https://github.com/user-attachments/assets/112ccd56-df3a-4c90-b720-339b48bace28" />
