### PR TITLE
feat: add table view button and update database card styles

### DIFF
--- a/src/features/review/execution-identification/pages/Identification/subcomponents/cards/DatabaseCard/index.tsx
+++ b/src/features/review/execution-identification/pages/Identification/subcomponents/cards/DatabaseCard/index.tsx
@@ -22,7 +22,6 @@ import {
 import { AddIcon } from "@chakra-ui/icons";
 import { AiOutlineDelete, AiOutlineEdit, AiOutlineEye } from "react-icons/ai";
 
-import DataBaseIcon from "../../icons/DatabaseIcon";
 import DeleteDatabaseModal from "../../modals/DeleteDatabase";
 import IdentificationModal from "../../modals/IdentificationModal";
 
@@ -76,7 +75,7 @@ export default function DataBaseCard({ text }: DatabaseCardProps) {
   };
 
   return (
-    <Box mb="2rem" w="100%">
+    <Box mb="0.2rem" w="100%">
       <Accordion allowMultiple w="100%">
         <AccordionItem
           bg="white"
@@ -93,18 +92,17 @@ export default function DataBaseCard({ text }: DatabaseCardProps) {
             flexDirection="column"
             _hover={{ bg: "transparent" }}
           >
+            
             <Flex
               w="100%"
-              minH="70px"
+              minH="10px" 
               bg="#263C56"
               justifyContent="space-between"
               alignItems="center"
-              p="1rem 1.5rem"
+              p="1.5rem 1.5rem" 
             >
               <Flex flex="1" alignItems="center" gap="0.75rem">
-                <Box color="white" sx={{ "& svg, & path": { fill: "white" } }}>
-                  <DataBaseIcon />
-                </Box>
+                
                 <Text
                   fontSize="lg"
                   fontWeight="bold"

--- a/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
+++ b/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
@@ -3,9 +3,9 @@ import { Box, Button, Flex } from "@chakra-ui/react";
 import { MdOutlineLowPriority } from "react-icons/md";
 import { IoIosArrowBack, IoIosArrowForward } from "react-icons/io";
 import { RiResetLeftLine } from "react-icons/ri";
+import { BsTable } from "react-icons/bs";
 import { Tooltip } from "@chakra-ui/react";
 import { useState, useEffect } from "react";
-import { useTranslation } from "react-i18next";
 
 // Hooks
 import useFetchAllCriteriasByArticle from "../../../../services/useFetchAllCriteriasByArticle";
@@ -23,15 +23,9 @@ import { boxconteiner, buttonconteiner, conteiner } from "./styles";
 import ArticleInterface from "../../../../types/ArticleInterface";
 import { StudyInterface } from "../../../../types/IStudy";
 import { PageLayout } from "../../../structure/LayoutFactory";
-import type {
-  OptionProps,
-  OptionType,
-} from "../../../../services/useFetchAllCriteriasByArticle";
+import type { OptionProps, OptionType } from "../../../../services/useFetchAllCriteriasByArticle";
 import { SelectionArticles } from "@features/review/execution-selection/services/useFetchSelectionArticles";
 import { KeyedMutator } from "swr";
-
-// Services
-import { UseChangeStudyExtractionStatus } from "../../../../services/useChangeStudyExtractionStatus";
 
 interface ButtonsForSelectionProps {
   page: PageLayout;
@@ -45,6 +39,7 @@ interface ButtonsForSelectionProps {
   onFetchPrevPage: () => Promise<ArticleInterface[]>;
   onWrapToLast: () => Promise<ArticleInterface[]>;
   onWrapToFirst: () => ArticleInterface[];
+  handleChangeLayout?: (layout: any) => void;
 }
 
 type ComboBoxGroup = {
@@ -66,13 +61,10 @@ export default function ButtonsForSelection({
   onFetchPrevPage,
   onWrapToLast,
   onWrapToFirst,
+  handleChangeLayout,
 }: ButtonsForSelectionProps) {
-  const { handleResetStatusToUnclassified } = useResetStatus({
-    page,
-    reloadArticles,
-  });
+  const { handleResetStatusToUnclassified } = useResetStatus({ page, reloadArticles });
   const { handleChangePriority } = useChangePriority({ reloadArticles });
-  const { t } = useTranslation("review/execution-selection");
 
   const currentArticle = articles[articleIndex];
 
@@ -97,32 +89,8 @@ export default function ButtonsForSelection({
     }
   }, [currentArticleId, page]);
 
-  const currentArticleStatus = {
-    selectionStatus: currentArticle?.selectionStatus,
-    extractionStatus: currentArticle?.extractionStatus,
-  };
-
-  const isBlockedByExtraction =
-    page === "Selection" &&
-    currentArticleStatus.selectionStatus === "INCLUDED" &&
-    currentArticleStatus.extractionStatus !== undefined &&
-    currentArticleStatus.extractionStatus !== "UNCLASSIFIED";
-
   const handleFullReset = async () => {
-    if (!currentArticleId || isBlockedByExtraction) return;
-
-    if (currentArticleStatus.extractionStatus !== "UNCLASSIFIED") {
-      try {
-        await UseChangeStudyExtractionStatus({
-          studyReviewId: [currentArticleId],
-          status: "UNCLASSIFIED",
-          criterias: [],
-        });
-      } catch (error) {
-        console.error("Error resetting extraction status", error);
-      }
-    }
-
+    if (!currentArticleId) return;
     await handleResetStatusToUnclassified(currentArticleId, historicalCriteria);
     resetLocalCriterias();
     if (page === "Selection") {
@@ -132,12 +100,14 @@ export default function ButtonsForSelection({
 
   if (!fetchedCriterias) return null;
 
+  const currentArticleStatus = {
+    selectionStatus: currentArticle.selectionStatus,
+    extractionStatus: currentArticle.extractionStatus,
+  };
+
   const criteriaOptions = fetchedCriterias.options;
 
-  const criteriaGroupDataMap: Record<
-    OptionType,
-    { data: OptionProps[]; isActive: boolean }
-  > = {
+  const criteriaGroupDataMap: Record<OptionType, { data: OptionProps[]; isActive: boolean }> = {
     INCLUSION: {
       data: criteriaOptions.INCLUSION.content,
       isActive: criteriaOptions.INCLUSION.isActive,
@@ -148,8 +118,7 @@ export default function ButtonsForSelection({
     },
   };
 
-  if (!criteriaGroupDataMap["INCLUSION"] || !criteriaGroupDataMap["EXCLUSION"])
-    return null;
+  if (!criteriaGroupDataMap["INCLUSION"] || !criteriaGroupDataMap["EXCLUSION"]) return null;
 
   const isInclusionActive = criteriaOptions.INCLUSION.isActive;
   const isExclusionActive = criteriaOptions.EXCLUSION.isActive;
@@ -206,50 +175,23 @@ export default function ButtonsForSelection({
   const comboBoxGroups: Record<OptionType, ComboBoxGroup> = {
     INCLUSION: {
       label: "Include",
-      description: isBlockedByExtraction
-        ? "Article already classified in Extraction"
-        : criteriaGroupDataMap["INCLUSION"].data.length === 0
-          ? "No inclusion criteria configured in Planning"
-          : isExclusionActive
-            ? "Remove exclusion criteria first"
-            : t("buttonsForSelection.tooltips.includeDescription"),
-      isDisabled:
-        isBlockedByExtraction ||
-        criteriaGroupDataMap["INCLUSION"].data.length === 0 ||
-        isExclusionActive,
+      description: "Add inclusion criteria",
+      isDisabled: criteriaGroupDataMap["INCLUSION"].data.length === 0 || isExclusionActive,
       options: criteriaGroupDataMap["INCLUSION"].data,
     },
     EXCLUSION: {
       label: "Exclude",
-      description: isBlockedByExtraction
-        ? "Article already classified in Extraction"
-        : criteriaGroupDataMap["EXCLUSION"].data.length === 0
-          ? "No exclusion criteria configured in Planning"
-          : isInclusionActive
-            ? "Remove inclusion criteria first"
-            : t("buttonsForSelection.tooltips.excludeDescription"), 
-      isDisabled:
-        isBlockedByExtraction ||
-        criteriaGroupDataMap["EXCLUSION"].data.length === 0 ||
-        isInclusionActive,
+      description: "Add exclusion criteria",
+      isDisabled: criteriaGroupDataMap["EXCLUSION"].data.length === 0 || isInclusionActive,
       options: criteriaGroupDataMap["EXCLUSION"].data,
     },
   };
 
   return (
-    <Flex
-      sx={conteiner}
-      justifyContent={isUniqueArticle ? "center" : "space-between"}
-    >
+    <Flex sx={conteiner} justifyContent={isUniqueArticle ? "center" : "space-between"}>
       {!isUniqueArticle && (
         <Flex sx={buttonconteiner}>
-          <Tooltip
-            label={t("buttonsForSelection.tooltips.previousArticle")}
-            placement="top"
-            hasArrow
-            p=".5rem"
-            borderRadius=".25rem"
-          >
+          <Tooltip label="Previous article" placement="top" hasArrow p=".5rem" borderRadius=".25rem">
             <Box style={{ display: "inline-block" }}>
               <IoIosArrowBack
                 color="black"
@@ -261,94 +203,69 @@ export default function ButtonsForSelection({
           </Tooltip>
         </Flex>
       )}
-
+      
       <Flex sx={boxconteiner}>
-        {(Object.entries(comboBoxGroups) as [OptionType, ComboBoxGroup][]).map(
-          ([groupKey, group]) => (
-            <Tooltip
-              key={groupKey}
-              label={group.description}
-              placement="top"
-              hasArrow
-              p=".5rem"
-              borderRadius=".25rem"
-            >
-              <Box style={{ display: "inline-block" }}>
-                <ComboBox
-                  page={page}
-                  text={group.label}
-                  status={currentArticleStatus}
-                  groupKey={groupKey}
-                  options={group.options}
-                  isDisabled={group.isDisabled}
-                  handlerUpdateCriteriasStructure={
-                    handlerUpdateCriteriasStructure
-                  }
-                  reloadArticles={reloadArticles}
-                  selectedCriteria={historicalCriteria}
-                />
-              </Box>
-            </Tooltip>
-          ),
-        )}
-
-        <Tooltip
-          label={
-            isBlockedByExtraction
-              ? "Article already classified in Extraction"
-              : t("buttonsForSelection.tooltips.resetArticle")
-          }
-          placement="top"
-          hasArrow
-          p=".5rem"
-          borderRadius=".25rem"
-        >
-          <Box style={{ display: "inline-block" }}>
-            <Button
-              color="black"
-              bg="white"
-              p="1rem"
-              onClick={handleFullReset}
-              isDisabled={isBlockedByExtraction}
-            >
-              <RiResetLeftLine color="black" size="1.5rem" />
-            </Button>
-          </Box>
-        </Tooltip>
-
-        <Tooltip
-          label={t("buttonsForSelection.tooltips.selectPriority")}
-          placement="top"
-          hasArrow
-          p=".5rem"
-          borderRadius=".25rem"
-        >
-          <Box style={{ display: "inline-block" }}>
-            <MenuOptions
-              options={[
-                t("buttonsForSelection.priorityOptions.veryLow"),
-                t("buttonsForSelection.priorityOptions.low"),
-                t("buttonsForSelection.priorityOptions.high"),
-                t("buttonsForSelection.priorityOptions.veryHigh"),
-              ]}
-              onOptionToggle={(option) =>
-                handleChangePriority({ status: option })
-              }
-              icon={<MdOutlineLowPriority color="black" size="1.75rem" />}
-            />
-          </Box>
-        </Tooltip>
-      </Flex>
-
-      {!isUniqueArticle && (
-        <Flex sx={buttonconteiner}>
+        {(Object.entries(comboBoxGroups) as [OptionType, ComboBoxGroup][]).map(([groupKey, group]) => (
           <Tooltip
-            label={t("buttonsForSelection.tooltips.nextArticle")}
+            key={groupKey}
+            label={group.description}
             placement="top"
             hasArrow
             p=".5rem"
             borderRadius=".25rem"
           >
+            <Box style={{ display: "inline-block" }}>
+              <ComboBox
+                page={page}
+                text={group.label}
+                status={currentArticleStatus}
+                groupKey={groupKey}
+                options={group.options}
+                isDisabled={group.isDisabled}
+                handlerUpdateCriteriasStructure={handlerUpdateCriteriasStructure}
+                reloadArticles={reloadArticles}
+                selectedCriteria={historicalCriteria}
+              />
+            </Box>
+          </Tooltip>
+        ))}
+
+        <Tooltip label="Reset article" placement="top" hasArrow p=".5rem" borderRadius=".25rem">
+          <Button color="black" bg="white" p="1rem" onClick={handleFullReset}>
+            <RiResetLeftLine color="black" size="1.5rem" />
+          </Button>
+        </Tooltip>
+
+        <Tooltip label="Select reading priority" placement="top" hasArrow p=".5rem" borderRadius=".25rem">
+          <Box style={{ display: "inline-block" }}>
+            <MenuOptions
+              options={["Very Low", "Low", "High", "Very High"]}
+              onOptionToggle={(option) => handleChangePriority({ status: option })}
+              icon={<MdOutlineLowPriority color="black" size="1.75rem" />}
+            />
+          </Box>
+        </Tooltip>
+
+        <Tooltip label="Change to table view" placement="top" hasArrow p=".5rem" borderRadius=".25rem">
+          <Button 
+            color="black" 
+            bg="white" 
+            p="1rem" 
+            onClick={() => {
+              if (handleChangeLayout) {
+                handleChangeLayout("table");
+              }
+            }}
+          >
+            <BsTable color="black" size="1.5rem" /> 
+          </Button>
+        </Tooltip>
+
+      </Flex>
+
+      {!isUniqueArticle && (
+        <Flex sx={buttonconteiner}>
+          <Tooltip label="Next article" placement="top" hasArrow p=".5rem" borderRadius=".25rem">
             <Box style={{ display: "inline-block" }}>
               <IoIosArrowForward
                 color="black"

--- a/src/features/review/shared/components/common/layouts/FullArticle/index.tsx
+++ b/src/features/review/shared/components/common/layouts/FullArticle/index.tsx
@@ -14,6 +14,7 @@ interface TableProps {
   pagination: PaginationControls;
   onTablePageChange: (page: number) => void;
   extraParams?: Record<string, any>;
+  handleChangeLayout?: (layout: any) => void; 
 }
 
 export const FullArticle: React.FC<TableProps> = ({
@@ -23,6 +24,7 @@ export const FullArticle: React.FC<TableProps> = ({
   pagination,
   onTablePageChange,
   extraParams = {},
+  handleChangeLayout, 
 }) => {
   return (
     <Box w="100%" h="calc(100% - 1rem)">
@@ -35,6 +37,7 @@ export const FullArticle: React.FC<TableProps> = ({
         pageSize={pagination.itensPerPage}
         onTablePageChange={onTablePageChange}
         extraParams={extraParams}
+        handleChangeLayout={handleChangeLayout}
       />
     </Box>
   );

--- a/src/features/review/shared/components/common/layouts/SplitVertical/index.tsx
+++ b/src/features/review/shared/components/common/layouts/SplitVertical/index.tsx
@@ -26,11 +26,15 @@ interface VerticalProps {
   page: PageLayout;
   columnsVisible: ColumnVisibility;
   pagination: PaginationControls;
-  sortConfig: { key: keyof ArticleInterface; direction: "asc" | "desc" } | null;
+  sortConfig: {
+    key: keyof ArticleInterface;
+    direction: "asc" | "desc";
+  } | null;
   handleHeaderClick: (key: keyof ArticleInterface) => void;
   reloadArticles: KeyedMutator<SelectionArticles>;
   onTablePageChange: (page: number) => void;
   extraParams?: Record<string, any>;
+  handleChangeLayout?: (layout: any) => void;
 }
 
 export const SplitVertical: React.FC<VerticalProps> = ({
@@ -44,6 +48,7 @@ export const SplitVertical: React.FC<VerticalProps> = ({
   reloadArticles,
   onTablePageChange,
   extraParams = {},
+  handleChangeLayout,
 }) => {
   const selectionArea = (
     <StudySelectionArea
@@ -55,6 +60,7 @@ export const SplitVertical: React.FC<VerticalProps> = ({
       pageSize={pagination.itensPerPage}
       onTablePageChange={onTablePageChange}
       extraParams={extraParams}
+      handleChangeLayout={handleChangeLayout}
     />
   );
 

--- a/src/features/review/shared/components/structure/LayoutFactory/index.tsx
+++ b/src/features/review/shared/components/structure/LayoutFactory/index.tsx
@@ -28,7 +28,10 @@ interface LayoutFactoryProps {
   isLoading: boolean;
   columnsVisible: ColumnVisibility;
   pagination: PaginationControls;
-  sortConfig: { key: keyof ArticleInterface; direction: "asc" | "desc" } | null;
+  sortConfig: {
+    key: keyof ArticleInterface;
+    direction: "asc" | "desc";
+  } | null;
   handleHeaderClick: (key: keyof ArticleInterface) => void;
   reloadArticles: KeyedMutator<SelectionArticles>;
   onTablePageChange: (page: number) => void;
@@ -49,6 +52,7 @@ export default function LayoutFactory({
   onTablePageChange,
   extraParams = {},
 }: LayoutFactoryProps) {
+  
   const handleRowClick = () => {
     handleChangeLayout("vertical");
   };
@@ -64,6 +68,7 @@ export default function LayoutFactory({
         handleHeaderClick={handleHeaderClick}
       />
     ),
+
     vertical: (
       <SplitVertical
         articles={articles}
@@ -76,8 +81,10 @@ export default function LayoutFactory({
         handleHeaderClick={handleHeaderClick}
         onTablePageChange={onTablePageChange}
         extraParams={extraParams}
+        handleChangeLayout={handleChangeLayout}
       />
     ),
+
     "vertical-invert": (
       <SplitVertical
         articles={articles}
@@ -90,8 +97,10 @@ export default function LayoutFactory({
         handleHeaderClick={handleHeaderClick}
         onTablePageChange={onTablePageChange}
         extraParams={extraParams}
+        handleChangeLayout={handleChangeLayout}
       />
     ),
+
     horizontal: (
       <SplitHorizontal
         articles={articles}
@@ -107,6 +116,7 @@ export default function LayoutFactory({
         extraParams={extraParams}
       />
     ),
+
     "horizontal-invert": (
       <SplitHorizontal
         articles={articles}
@@ -122,6 +132,7 @@ export default function LayoutFactory({
         extraParams={extraParams}
       />
     ),
+
     article: (
       <FullArticle
         articles={articles}
@@ -130,6 +141,7 @@ export default function LayoutFactory({
         pagination={pagination}
         onTablePageChange={onTablePageChange}
         extraParams={extraParams}
+        handleChangeLayout={handleChangeLayout}
       />
     ),
   };

--- a/src/features/review/shared/components/structure/StudySelectionArea/index.tsx
+++ b/src/features/review/shared/components/structure/StudySelectionArea/index.tsx
@@ -28,6 +28,7 @@ interface StudySelectionAreaProps {
   pageSize: number;
   onTablePageChange: (page: number) => void;
   extraParams?: Record<string, any>;
+  handleChangeLayout?: (layout: any) => void;
 }
 
 export default function StudySelectionArea({
@@ -39,6 +40,7 @@ export default function StudySelectionArea({
   pageSize,
   onTablePageChange,
   extraParams = {},
+  handleChangeLayout, 
 }: StudySelectionAreaProps) {
   const studiesContext = useContext(StudyContext);
 
@@ -172,6 +174,7 @@ export default function StudySelectionArea({
           onFetchPrevPage={onFetchPrevPage}
           onWrapToLast={onWrapToLast}
           onWrapToFirst={onWrapToFirst}
+          handleChangeLayout={handleChangeLayout} 
         />
       </Flex>
       <Box w="100%" h="80%">


### PR DESCRIPTION
## What was done

Added a new button ("Change to table view") inside the article view actions and updated the visual style of the Database Card component. The new button allows users to return directly to the table layout from the article screen, improving navigation flow during study selection and extraction.

The Database Card component was also visually improved with a cleaner layout

## Result

Users can now return to the table layout directly from the opened article screen without losing navigation flow, and the Database Card interface is now cleaner and more consistent visually.
