### PR TITLE
feat(BO-70): unify graphics menu with scroll and full i18n support

### DIFF
--- a/src/features/review/summarization-graphics/components/menus/SectionMenu/index.tsx
+++ b/src/features/review/summarization-graphics/components/menus/SectionMenu/index.tsx
@@ -8,67 +8,92 @@ import {
   MenuGroup,
   MenuItem,
   MenuList,
+  Tooltip,
 } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 
 type MenuProps = {
   onSelect: (section: string) => void;
   selected: string;
+  questions?: any[];
 };
 
 type Section = {
   label: string;
   value: string;
   group?: string;
-  displayName?: string; 
+  displayName?: string;
+  tooltip?: string;
 };
 
-export default function SectionMenu({ onSelect, selected }: MenuProps) {
+const getQuestionTooltip = (code: string, t: any): string => {
+  const num = code.replace(/[^0-9]/g, "");
+  if (code.startsWith("EQ")) return `Extraction Question ${num}`;
+  if (code.startsWith("RBQ")) return `Risk of Bias Question ${num}`;
+  return code;
+};
+
+export default function SectionMenu({ onSelect, selected, questions = [] }: MenuProps) {
   const { t } = useTranslation("review/summarization-graphics");
 
-  const sections: Section[] = [
-    { label: t("sectionMenu.sections.searchSources"), value: "Search Sources" },
+  const staticSections: Section[] = [
+    {
+      label: t("sectionMenu.sections.searchSources"),
+      value: "Search Sources",
+    },
     {
       label: t("sectionMenu.sections.s1InclusionCriteria"),
       value: "S1_Inclusion Criteria",
       group: "First Selection",
-      displayName: "First Selection - Inclusion Criteria",
+      displayName: `First Selection - ${t("sectionMenu.sections.s1InclusionCriteria")}`,
     },
     {
       label: t("sectionMenu.sections.s1ExclusionCriteria"),
       value: "S1_Exclusion Criteria",
       group: "First Selection",
-      displayName: "First Selection - Exclusion Criteria",
+      displayName: `First Selection - ${t("sectionMenu.sections.s1ExclusionCriteria")}`,
     },
     {
       label: t("sectionMenu.sections.s2InclusionCriteria"),
       value: "S2_Inclusion Criteria",
       group: "Second Selection",
-      displayName: "Second Selection - Inclusion Criteria",
+      displayName: `Second Selection - ${t("sectionMenu.sections.s2InclusionCriteria")}`,
     },
     {
       label: t("sectionMenu.sections.s2ExclusionCriteria"),
       value: "S2_Exclusion Criteria",
       group: "Second Selection",
-      displayName: "Second Selection - Exclusion Criteria",
+      displayName: `Second Selection - ${t("sectionMenu.sections.s2ExclusionCriteria")}`,
     },
-    { label: t("sectionMenu.sections.studiesFunnel"), value: "Studies Funnel" },
+    {
+      label: t("sectionMenu.sections.studiesFunnel"),
+      value: "Studies Funnel",
+    },
     {
       label: t("sectionMenu.sections.includedStudies"),
       value: "Included Studies",
     },
-    { label: t("sectionMenu.sections.formQuestions"), value: "Form Questions" },
   ];
 
-  const groupedSections = sections.reduce(
-    (acc, section) => {
-      const group = section.group || "ungrouped";
-      if (!acc[group]) acc[group] = [];
-      acc[group].push(section);
-      return acc;
-    },
-    {} as Record<string, Section[]>,
-  );
+  const allSections: Section[] = [
+    ...staticSections,
+    ...questions.map((q) => ({
+      label: q.code,
+      value: q.questionId,
+      group: "Form Questions",
+      displayName: `Form Question - ${q.code}`,
+      tooltip: getQuestionTooltip(q.code, t),
+    })),
+  ];
+
+  const groupedSections = allSections.reduce((acc, section) => {
+    const group = section.group || "ungrouped";
+    if (!acc[group]) acc[group] = [];
+    acc[group].push(section);
+    return acc;
+  }, {} as Record<string, Section[]>);
+
+  const current = allSections.find((s) => s.value === selected);
 
   return (
     <Menu>
@@ -82,17 +107,20 @@ export default function SectionMenu({ onSelect, selected }: MenuProps) {
       >
         <Flex w="100%" justifyContent="space-between" alignItems="center">
           <Box>
-            {(() => {
-              const current = sections.find((s) => s.value === selected);
-              if (!current) return t("sectionMenu.chooseSection");
-              return current.displayName || current.label;
-            })()}
+            {current ? (current.displayName || current.label) : t("sectionMenu.overview")}
           </Box>
           <ChevronDownIcon fontSize="1.25rem" />
         </Flex>
       </MenuButton>
 
-      <MenuList bg="#EBF0F3" color="#2E4B6C" zIndex="2000">
+      <MenuList
+        bg="#EBF0F3"
+        color="#2E4B6C"
+        zIndex="2000"
+        maxH="400px"
+        overflowY="auto"
+        overflowX="hidden"
+      >
         {Object.entries(groupedSections).map(([groupName, items]) => {
           const isUngrouped = groupName === "ungrouped";
 
@@ -100,9 +128,7 @@ export default function SectionMenu({ onSelect, selected }: MenuProps) {
             <Box key={groupName}>
               {!isUngrouped && (
                 <MenuGroup
-                  title={t(
-                    `sectionMenu.groups.${groupName.toLowerCase().replace(" ", "_")}`,
-                  )}
+                  title={t(`sectionMenu.groups.${groupName.toLowerCase().replace(" ", "_")}`, groupName)}
                   bg="#EBF0F3"
                   ml="3"
                   fontSize="md"
@@ -110,15 +136,26 @@ export default function SectionMenu({ onSelect, selected }: MenuProps) {
                 />
               )}
               {items.map((item) => (
-                <MenuItem
+                <Tooltip
                   key={item.value}
-                  onClick={() => onSelect(item.value)}
-                  ml={isUngrouped ? "0" : "1"}
-                  bg={selected === item.value ? "blue.100" : "transparent"}
-                  _hover={{ bg: "blue.200" }}
+                  label={item.tooltip || ""}
+                  placement="left"
+                  hasArrow
+                  isDisabled={!item.tooltip}
+                  bg="#2E4B6C"
+                  color="white"
+                  borderRadius="md"
+                  fontSize="sm"
                 >
-                  {item.label}
-                </MenuItem>
+                  <MenuItem
+                    onClick={() => onSelect(item.value)}
+                    ml={isUngrouped ? "0" : "1"}
+                    bg={selected === item.value ? "blue.100" : "transparent"}
+                    _hover={{ bg: "blue.200" }}
+                  >
+                    {item.label}
+                  </MenuItem>
+                </Tooltip>
               ))}
             </Box>
           );

--- a/src/features/review/summarization-graphics/pages/Graphics/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/index.tsx
@@ -26,63 +26,61 @@ export default function Graphics() {
   } = useGraphicsState();
   const { t } = useTranslation("review/summarization-graphics");
 
+  const handleUnifiedSelection = (value: string) => {
+    const isQuestion = allQuestions.some(q => q.questionId === value);
+
+    if (isQuestion) {
+      handleSectionChange("Form Questions");
+      setSelectedQuestionId(value);
+    } 
+    else {
+      handleSectionChange(value);
+      setSelectedQuestionId(undefined);
+    }
+  };
+
   return (
-    <FlexLayout navigationType="Accordion">
-      <Flex justifyContent="space-between" alignItems="flex-start" w="100%" mb="1rem">
-        
-        <Flex flexDirection="column" gap="0.75rem">
-          <Header text={t("header")} />
+<FlexLayout navigationType="Accordion">
+  <Flex justifyContent="space-between" alignItems="flex-start" w="100%" mb="1rem">
+    <Flex flexDirection="column" gap="0.75rem">
+      <Header text={t("header")} />
 
-          {filtersBySection[section]?.length > 0 && (
-            <Flex flexDirection="column" gap="0.5rem">
-              <Text fontWeight="semibold" fontSize="lg" color="#263C56">
-                {t("filtersArea.heading")}
-              </Text>
-              <FiltersMenu
-                availableFilters={filtersBySection[section]}
-                filters={filters}
-                setFilters={setFilters}
-              />
-            </Flex>
-          )}
+      {filtersBySection[section]?.length > 0 && (
+        <Flex flexDirection="column" gap="0.5rem">
+          <Text fontWeight="semibold" fontSize="lg" color="#263C56">
+            {t("filtersArea.heading")}
+          </Text>
+          <FiltersMenu
+            availableFilters={filtersBySection[section]}
+            filters={filters}
+            setFilters={setFilters}
+          />
         </Flex>
+      )}
+    </Flex>
+    <Flex flexDirection="column" gap="0.5rem" mt="0.75rem">
+      <SectionMenu 
+        onSelect={handleUnifiedSelection} 
+        selected={selectedQuestionId || section} 
+        questions={allQuestions.filter(q => q.questionId !== null)}
+      />
+      
+      {section && !(
+        section === "Studies Funnel" ||
+        section === "Form Questions" ||
+        section === "Protocol"
+      ) && (
+        <SelectMenu
+          options={currentAllowedTypes}
+          selected={type}
+          onSelect={setType}
+          placeholder={t("selectMenu.chooseLayout")}
+        />
+      )}
+    </Flex>
+  </Flex>
 
-        <Flex flexDirection="column" gap="0.5rem" mt="0.75rem">
-          <SectionMenu onSelect={handleSectionChange} selected={section} />
-          {!(
-            section === "Studies Funnel" ||
-            section === "Form Questions" ||
-            section === "Protocol"
-          ) && (
-            <SelectMenu
-              options={currentAllowedTypes}
-              selected={type}
-              onSelect={setType}
-              placeholder={t("selectMenu.chooseLayout")}
-            />
-          )}
-          {section === "Form Questions" && (
-            <SelectMenu
-              options={allQuestions.filter((q) => q.questionId !== null)}
-              selected={allQuestions.find(
-                (q) => q.questionId === selectedQuestionId
-              )}
-              onSelect={(q) =>
-                setSelectedQuestionId(q.questionId ?? undefined)
-              }
-              getLabel={(q) => q.code}
-              getKey={(q) => q.questionId ?? q.code}
-              placeholder="Choose Question"
-            />
-          )}
-        </Flex>
-      </Flex>
-
-  <CardDefault
-    backgroundColor="#fff"
-    borderRadius="1rem"
-    withShadow={false}
-  >
+  <CardDefault backgroundColor="#fff" borderRadius="1rem" withShadow={false}>
     <ExportProvider>
       {section ? (
         <ChartsRenderer
@@ -93,24 +91,19 @@ export default function Graphics() {
           selectedQuestionId={selectedQuestionId}
         />
       ) : (
-        /* Render placeholder when section is not yet defined */
-        <Flex 
-          direction="column" 
-          align="center" 
-          justify="center" 
-          h="800px" 
-          textAlign="center"
-        >
+        <Flex direction="column" align="center" justify="center" h="800px" textAlign="center">
           <Text fontSize="34px" fontWeight="bold" color="#2E4B6C" mb="2">
-            Graphics Area
+            {t("graphicsArea.title") === "graphicsArea.title" ? "Graphics Area" : t("graphicsArea.title")}
           </Text>
           <Text fontSize="19px" color="gray.600">
-            Please select a section and layout above to view the data.
+            {t("graphicsArea.instruction") === "graphicsArea.instruction" 
+              ? "Switch between sections above to view specific data or keep the overview." 
+              : t("graphicsArea.instruction")}
           </Text>
         </Flex>
       )}
     </ExportProvider>
   </CardDefault>
-    </FlexLayout>
+</FlexLayout>
   );
 }

--- a/src/locales/en/review/summarization-graphics.json
+++ b/src/locales/en/review/summarization-graphics.json
@@ -8,6 +8,7 @@
         "endYear": "End Year"
     },
     "sectionMenu": {
+      "overview": "Overview",
       "chooseSection": "Choose Section",
       "sections": {
         "searchSources": "Search Sources",

--- a/src/locales/pt/review/summarization-graphics.json
+++ b/src/locales/pt/review/summarization-graphics.json
@@ -1,28 +1,35 @@
 {
     "header": "Gráficos",
     "filtersArea": {
-        "heading":"Área de Filtros",
+        "heading": "Área de Filtros",
         "sources": "Fontes",
         "criteria": "Critérios",
         "startYear": "Ano de Início",
         "endYear": "Ano de Término"
     },
     "sectionMenu": {
-      "chooseSection": "Escolher Seção",
-      "sections": {
-        "searchSources": "Fontes de Busca",
-        "s1InclusionCriteria": "Critérios de Inclusão",
-        "s1ExclusionCriteria": "Critérios de Exclusão",
-        "s2InclusionCriteria": "Critérios de Inclusão",
-        "s2ExclusionCriteria": "Critérios de Exclusão",
-        "studiesFunnel": "Funil de Estudos",
-        "includedStudies": "Estudos Incluídos",
-        "formQuestions": "Questões do Formulário"
-      },
-      "groups": {
-        "first_selection": "Primeira Seleção",
-        "second_selection": "Segunda Seleção"
-      }
+        "overview": "Visão Geral",
+        "chooseSection": "Visão Geral",
+        "sections": {
+            "searchSources": "Fontes de Busca",
+            "s1InclusionCriteria": "Critérios de Inclusão",
+            "s1ExclusionCriteria": "Critérios de Exclusão",
+            "s2InclusionCriteria": "Critérios de Inclusão",
+            "s2ExclusionCriteria": "Critérios de Exclusão",
+            "studiesFunnel": "Funil de Estudos",
+            "includedStudies": "Estudos Incluídos",
+            "formQuestions": "Questões do Formulário"
+        },
+        "groups": {
+            "first_selection": "Primeira Seleção",
+            "second_selection": "Segunda Seleção",
+            "form_questions": "Perguntas do Formulário"
+        },
+        "tooltips": {
+            "inclusion": "Critério de Inclusão",
+            "exclusion": "Critério de Exclusão",
+            "rbq": "Questão de Risco de Viés"
+        }
     },
     "selectMenu": {
         "chooseLayout": "Escolher Layout",


### PR DESCRIPTION
Unifiquei os menus de seções estáticas e dinâmicas, substituindo o termo "Choose Section" por "Overview/Visão Geral" como estado padrão. Adicionei scroll vertical no componente para comportar a lista de questões e implementei a tradução completa para as chaves de "Overview" e para o grupo "Form Questions". Por fim, adicionei tooltips explicativos para identificar as questões de Risco de Viés (RBQ) e Extração (EQ/Extraction).