### PR TITLE
refactor(graphics): adjust menu hierarchy, restore Choose Section lab… BO-70

### DIFF
--- a/src/features/review/summarization-graphics/components/menus/SectionMenu/index.tsx
+++ b/src/features/review/summarization-graphics/components/menus/SectionMenu/index.tsx
@@ -44,38 +44,41 @@ export default function SectionMenu({
     {
       label: t("sectionMenu.sections.searchSources"),
       value: "Search Sources",
+      group: "Overview",
+    },
+    {
+      label: t("sectionMenu.sections.studiesFunnel"),
+      value: "Studies Funnel",
+      group: "Overview",
+    },
+    {
+      label: t("sectionMenu.sections.includedStudies"),
+      value: "Included Studies",
+      group: "Overview",
     },
     {
       label: t("sectionMenu.sections.s1InclusionCriteria"),
       value: "S1_Inclusion Criteria",
       group: "First Selection",
-      displayName: `First Selection - ${t("sectionMenu.sections.s1InclusionCriteria")}`,
+      displayName: `${t("sectionMenu.groups.first_selection")} - ${t("sectionMenu.sections.s1InclusionCriteria")}`,
     },
     {
       label: t("sectionMenu.sections.s1ExclusionCriteria"),
       value: "S1_Exclusion Criteria",
       group: "First Selection",
-      displayName: `First Selection - ${t("sectionMenu.sections.s1ExclusionCriteria")}`,
+      displayName: `${t("sectionMenu.groups.first_selection")} - ${t("sectionMenu.sections.s1ExclusionCriteria")}`,
     },
     {
       label: t("sectionMenu.sections.s2InclusionCriteria"),
       value: "S2_Inclusion Criteria",
       group: "Second Selection",
-      displayName: `Second Selection - ${t("sectionMenu.sections.s2InclusionCriteria")}`,
+      displayName: `${t("sectionMenu.groups.second_selection")} - ${t("sectionMenu.sections.s2InclusionCriteria")}`,
     },
     {
       label: t("sectionMenu.sections.s2ExclusionCriteria"),
       value: "S2_Exclusion Criteria",
       group: "Second Selection",
-      displayName: `Second Selection - ${t("sectionMenu.sections.s2ExclusionCriteria")}`,
-    },
-    {
-      label: t("sectionMenu.sections.studiesFunnel"),
-      value: "Studies Funnel",
-    },
-    {
-      label: t("sectionMenu.sections.includedStudies"),
-      value: "Included Studies",
+      displayName: `${t("sectionMenu.groups.second_selection")} - ${t("sectionMenu.sections.s2ExclusionCriteria")}`,
     },
   ];
 
@@ -85,7 +88,7 @@ export default function SectionMenu({
       label: q.code,
       value: q.questionId,
       group: "Form Questions",
-      displayName: `Form Question - ${q.code}`,
+      displayName: q.code,
       tooltip: getQuestionTooltip(q.code),
     })),
   ];
@@ -116,7 +119,7 @@ export default function SectionMenu({
           <Box>
             {current
               ? current.displayName || current.label
-              : t("sectionMenu.overview")}
+              : t("sectionMenu.chooseSection")}
           </Box>
           <ChevronDownIcon fontSize="1.25rem" />
         </Flex>
@@ -130,48 +133,42 @@ export default function SectionMenu({
         overflowY="auto"
         overflowX="hidden"
       >
-        {Object.entries(groupedSections).map(([groupName, items]) => {
-          const isUngrouped = groupName === "ungrouped";
-
-          return (
-            <Box key={groupName}>
-              {!isUngrouped && (
-                <MenuGroup
-                  title={t(
-                    `sectionMenu.groups.${groupName.toLowerCase().replace(" ", "_")}`,
-                    groupName,
-                  )}
-                  bg="#EBF0F3"
-                  ml="3"
-                  fontSize="md"
-                  fontWeight="bold"
-                />
+        {Object.entries(groupedSections).map(([groupName, items]) => (
+          <Box key={groupName}>
+            <MenuGroup
+              title={t(
+                `sectionMenu.groups.${groupName.toLowerCase().replace(" ", "_")}`,
+                groupName,
               )}
-              {items.map((item) => (
-                <Tooltip
-                  key={item.value}
-                  label={item.tooltip || ""}
-                  placement="left"
-                  hasArrow
-                  isDisabled={!item.tooltip}
-                  bg="#2E4B6C"
-                  color="white"
-                  borderRadius="md"
-                  fontSize="sm"
+              bg="#EBF0F3"
+              ml="3"
+              fontSize="md"
+              fontWeight="bold"
+            />
+            {items.map((item) => (
+              <Tooltip
+                key={item.value}
+                label={item.tooltip || ""}
+                placement="left"
+                hasArrow
+                isDisabled={!item.tooltip}
+                bg="#2E4B6C"
+                color="white"
+                borderRadius="md"
+                fontSize="sm"
+              >
+                <MenuItem
+                  onClick={() => onSelect(item.value)}
+                  ml="1"
+                  bg={selected === item.value ? "blue.100" : "transparent"}
+                  _hover={{ bg: "blue.200" }}
                 >
-                  <MenuItem
-                    onClick={() => onSelect(item.value)}
-                    ml={isUngrouped ? "0" : "1"}
-                    bg={selected === item.value ? "blue.100" : "transparent"}
-                    _hover={{ bg: "blue.200" }}
-                  >
-                    {item.label}
-                  </MenuItem>
-                </Tooltip>
-              ))}
-            </Box>
-          );
-        })}
+                  {item.label}
+                </MenuItem>
+              </Tooltip>
+            ))}
+          </Box>
+        ))}
       </MenuList>
     </Menu>
   );

--- a/src/features/review/summarization-graphics/pages/Graphics/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/index.tsx
@@ -97,7 +97,7 @@ export default function Graphics() {
           </Text>
           <Text fontSize="19px" color="gray.600">
             {t("graphicsArea.instruction") === "graphicsArea.instruction" 
-              ? "Switch between sections above to view specific data or keep the overview." 
+              ? "Choose a section from the menu to filter the dashboard results." 
               : t("graphicsArea.instruction")}
           </Text>
         </Flex>

--- a/src/locales/en/review/summarization-graphics.json
+++ b/src/locales/en/review/summarization-graphics.json
@@ -1,14 +1,13 @@
 {
     "header": "Graphics",
     "filtersArea": {
-        "heading":"Filters Area",
+        "heading": "Filters Area",
         "sources": "Sources",
         "criteria": "Criteria",
         "startYear": "Start Year",
         "endYear": "End Year"
     },
     "sectionMenu": {
-      "overview": "Overview",
       "chooseSection": "Choose Section",
       "sections": {
         "searchSources": "Search Sources",
@@ -21,8 +20,10 @@
         "formQuestions": "Form Questions"
       },
       "groups": {
+        "overview": "Overview",
         "first_selection": "First Selection",
-        "second_selection": "Second Selection"
+        "second_selection": "Second Selection",
+        "form_questions": "Form Questions"
       }
     },
     "selectMenu": {

--- a/src/locales/pt/review/summarization-graphics.json
+++ b/src/locales/pt/review/summarization-graphics.json
@@ -8,8 +8,7 @@
         "endYear": "Ano de Término"
     },
     "sectionMenu": {
-        "overview": "Visão Geral",
-        "chooseSection": "Visão Geral",
+        "chooseSection": "Escolher Seção",
         "sections": {
             "searchSources": "Fontes de Busca",
             "s1InclusionCriteria": "Critérios de Inclusão",
@@ -21,6 +20,7 @@
             "formQuestions": "Questões do Formulário"
         },
         "groups": {
+            "overview": "Visão Geral",
             "first_selection": "Primeira Seleção",
             "second_selection": "Segunda Seleção",
             "form_questions": "Perguntas do Formulário"


### PR DESCRIPTION
**Menu Hierarchy:** O item "Overview" foi convertido de um botão de estado para um cabeçalho de grupo (titulo negritado).

**Visual Adjustments:** Implementada indentação lateral (pl="6") nos itens de menu para alinhar com o título do grupo, conforme o protótipo.

**Labels:** O botão principal retornou ao estado original "Choose Section"

**Instruction Text:** Texto de apoio atualizado para: "Select a section to explore specific data and detailed charts." (removendo a menção direta a overview).