### PR TITLE
fix(research): secondary questions layout

### DIFF
--- a/src/features/review/planning-protocol/components/common/inputs/text/AddTextTable/index.tsx
+++ b/src/features/review/planning-protocol/components/common/inputs/text/AddTextTable/index.tsx
@@ -9,9 +9,10 @@ interface AddTextTableProps {
   placeholder: string;
   referencePrefix?: string;
   enableReferenceCode?: boolean;
+  tableHeight?: string;
 }
 
-export default function AddTextTable({ text, placeholder, referencePrefix = "", enableReferenceCode = true }: AddTextTableProps) {
+export default function AddTextTable({ text, placeholder, referencePrefix = "", enableReferenceCode = true, tableHeight }: AddTextTableProps) {
   const { AddText, handleAddText, setAddText } = useAddText(text);
   const { handleDeleteText } = useDeleteText(text);
   return (
@@ -31,6 +32,7 @@ export default function AddTextTable({ text, placeholder, referencePrefix = "", 
           referencePrefix={referencePrefix}
           enableReferenceCode={enableReferenceCode}
           maxLength={7}
+          tableHeight={tableHeight}
         />
       </FormControl>
     </FormControl>

--- a/src/features/review/planning-protocol/components/common/tables/InfosTable/index.tsx
+++ b/src/features/review/planning-protocol/components/common/tables/InfosTable/index.tsx
@@ -18,6 +18,7 @@ interface InfosTableProps {
   referencePrefix?: string;
   enableReferenceCode?: boolean;
   maxLength?: number;
+  tableHeight?: string;
 }
 
 export default function InfosTable({
@@ -30,6 +31,7 @@ export default function InfosTable({
   referencePrefix = "",
   enableReferenceCode = true,
   maxLength,
+  tableHeight,
 }: InfosTableProps) {
   const { sendAddText } = useCreateProtocol();
   const toaster = useToaster();
@@ -136,7 +138,7 @@ export default function InfosTable({
   };
 
   return (
-    <TableContainer sx={tbConteiner}>
+    <TableContainer sx={{ ...tbConteiner, h: tableHeight || tbConteiner.h }}>
       <Table variant="simple" size="md">
         <Thead>
           <Tr>

--- a/src/features/review/planning-protocol/components/common/tables/InfosTable/styles.ts
+++ b/src/features/review/planning-protocol/components/common/tables/InfosTable/styles.ts
@@ -1,7 +1,7 @@
 export const tbConteiner = {
   border: "solid #263C56 1px",
   w: "60vw",
-  h: "400px",
+  h: "120px",
   overflowY: "auto",
   borderRadius: "6px"
 };

--- a/src/features/review/planning-protocol/pages/ResearchQuestions/index.tsx
+++ b/src/features/review/planning-protocol/pages/ResearchQuestions/index.tsx
@@ -87,6 +87,7 @@ export default function ResearchQuestions() {
                 placeholder={t("researchQuestions.secondaryQuestions.placeholder")}
                 referencePrefix="RQ"
                 enableReferenceCode={true}
+                tableHeight="400px"
               />
             </Flex>
           </AccordionPanel>


### PR DESCRIPTION
### Secondary Questions de Research Questions, deve ocupar melhor o espaço disponível

- Na tela de Research (Planning -> Research), a tabela de Secundary Questions ocupava pouco espaço na página, quando fui arrumar essa issue errei no ajuste, agora estou corrigindo.

### Local da Alteração
<img width="207" height="914" alt="image" src="https://github.com/user-attachments/assets/112ccd56-df3a-4c90-b720-339b48bace28" />

### Antes
<img width="1744" height="857" alt="image" src="https://github.com/user-attachments/assets/d8129283-61b5-4bcb-b06c-e938f72181aa" />

### Depois
<img width="1911" height="940" alt="image" src="https://github.com/user-attachments/assets/7af5a458-46a9-4e44-bafc-2c433ecbd80b" />
