### PR TITLE
GM-feat-internationalization-RoB-and-selection

### DIFF
--- a/src/features/review/execution-extraction/components/forms/DataExtraction/index.tsx
+++ b/src/features/review/execution-extraction/components/forms/DataExtraction/index.tsx
@@ -12,6 +12,7 @@ import {
 } from "@chakra-ui/react";
 import { FaPlusCircle } from "react-icons/fa";
 import { BsSend } from "react-icons/bs";
+import { useTranslation } from "react-i18next";
 
 // Component
 import CreateResponseComponent from "@features/review/execution-extraction/factory/CreateResponseComponents/index.tsx";
@@ -47,6 +48,7 @@ export default function DataExtraction({
 }: DataExtractionFormProps) {
   const reviewId = localStorage.getItem("systematicReviewId");
   const { toGo } = useNavigation();
+  const { t } = useTranslation("review/execution-extraction");
 
   const { submitResponses } = useExtractionFormSubmission({
     responses: questions ?? {},
@@ -130,8 +132,8 @@ export default function DataExtraction({
 
    if (!isModified) {
      toast({
-       title: "No changes made",
-       description: "Update at least one answer before submitting.",
+       title: t("extractionForm.noChangesToast.title"),
+       description: t("extractionForm.noChangesToast.description"),
        status: "warning",
        duration: 4000,
        isClosable: true,
@@ -189,7 +191,7 @@ export default function DataExtraction({
                     bg="gray.50"
                   >
                     <Text fontSize="md" fontWeight="bold" color="gray.800">
-                      No questions found
+                      {t("extractionForm.noQuestions")}
                     </Text>
 
                     <Button
@@ -203,7 +205,7 @@ export default function DataExtraction({
                         )
                       }
                     >
-                      Create Questions
+                      {t("extractionForm.createQuestions")}
                     </Button>
                   </Flex>
                 </Box>
@@ -253,7 +255,7 @@ export default function DataExtraction({
                           fontWeight="semibold"
                           mb="0.4rem"
                         >
-                          * This field is required
+                          {t("extractionForm.requiredField")}
                         </Text>
                       )}
                       <CreateResponseComponent
@@ -286,7 +288,7 @@ export default function DataExtraction({
             px="1.5rem"
             width="6.5rem"
           >
-            Submit
+            {t("extractionForm.submit")}
           </Button>
         </Flex>
       )}

--- a/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/DropdownList/index.tsx
+++ b/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/DropdownList/index.tsx
@@ -1,6 +1,7 @@
 // External library
 import { useState } from "react";
 import { FormControl, FormLabel } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 
 // Components
 import SelectInput from "@components/common/inputs/SelectInput";
@@ -28,7 +29,8 @@ export default function DropdownList({
   onResponse,
 }: DropdownListProps) {
   const [selected, setSelected] = useState(answer);
-
+  const { t } = useTranslation("review/execution-extraction");
+  
   const handleSelectChange = (value: string) => {
     setSelected(value);
     onResponse(value);
@@ -43,7 +45,7 @@ export default function DropdownList({
         onSelect={handleSelectChange}
         selectedValue={selected}
         page="extraction"
-        placeholder="Options"
+        placeholder={t("extractionForm.dropdownList")}
         isInvalid={isInvalid}
       />
     </FormControl>

--- a/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/LabeledList/index.tsx
+++ b/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/LabeledList/index.tsx
@@ -1,6 +1,7 @@
 // External library
 import { useEffect, useState } from "react";
 import { FormControl, FormLabel } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 
 // Components
 import SelectInput from "@components/common/inputs/SelectInput";
@@ -28,7 +29,8 @@ export default function LabeledList({
   onResponse,
 }: LabeledListProps) {
   const [selected, setSelected] = useState("");
-
+  const { t } = useTranslation("review/execution-extraction");
+  
   const options = Object.entries(scales).map(
     ([key, value]) => `${key}: ${value}`,
   );
@@ -46,7 +48,6 @@ export default function LabeledList({
       setSelected(answer);
       return;
     }
-
     const formattedAnswer = `${answer.name}: ${answer.value}`;
     setSelected(formattedAnswer);
   }, [answer]);
@@ -60,7 +61,7 @@ export default function LabeledList({
         onSelect={handleSelectChange}
         selectedValue={selected}
         page="extraction"
-        placeholder="Labels"
+        placeholder={t("extractionForm.labeledList")}
         isInvalid={isInvalid}
       />
     </FormControl>

--- a/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/NumberScale/index.tsx
+++ b/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/NumberScale/index.tsx
@@ -10,6 +10,7 @@ import {
   RadioGroup,
   Text,
 } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 
 // Utils
 import { capitalize } from "@features/shared/utils/helpers/formatters/CapitalizeText";
@@ -43,7 +44,8 @@ export default function NumberScale({
   onResponse,
 }: NumberScaleProps) {
   const [checkedOption, setCheckedOption] = useState<string>(answer);
-
+  const { t } = useTranslation("review/execution-extraction");
+  
   const scaleValues = Array.from(
     { length: maxValue - minValue + 1 },
     (_, i) => minValue + i,
@@ -78,7 +80,7 @@ export default function NumberScale({
         </RadioGroup>
         {checkedOption && (
           <Button sx={clearButton} onClick={handleClearSelection}>
-            Clear selection
+            {t("extractionForm.clearSelection")}
           </Button>
         )}
       </Box>

--- a/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/Textual/index.tsx
+++ b/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/Textual/index.tsx
@@ -1,6 +1,7 @@
 // External library
 import React, { useState } from "react";
 import { FormControl, FormLabel, Textarea } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 
 // Utils
 import { capitalize } from "@features/shared/utils/helpers/formatters/CapitalizeText";
@@ -24,6 +25,7 @@ export default function TextualResponse({
   onResponse,
 }: TextualResponseProps) {
   const [response, setResponse] = useState<string>(answer);
+  const { t } = useTranslation("review/execution-extraction");
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value;
@@ -40,7 +42,7 @@ export default function TextualResponse({
         sx={responseArea}
         isInvalid={isInvalid}
         _placeholder={{ opacity: 1, color: "gray.500" }}
-        placeholder="Your response"
+        placeholder={t("extractionForm.textual")}
         focusBorderColor="#2E4B6C"
       />
     </FormControl>

--- a/src/features/review/execution-extraction/components/forms/ExtractionForm/index.tsx
+++ b/src/features/review/execution-extraction/components/forms/ExtractionForm/index.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex, Text, Icon, VStack } from "@chakra-ui/react";
 import { LockIcon } from "@chakra-ui/icons";
+import { useTranslation } from "react-i18next";
 
 // Components
 import HeaderForm from "../DataExtraction/subcomponents/Header";
@@ -23,6 +24,7 @@ export default function ExtractionForm({ studyData }: ArticlePreviewProps) {
     mutateQuestion,
     isLoading,
   } = useFetchAllQuestionsByArticle();
+  const { t } = useTranslation("review/execution-extraction");
 
   if (isLoading) return <SkeletonLoader height="100%" width="100%" />;
 
@@ -49,7 +51,7 @@ export default function ExtractionForm({ studyData }: ArticlePreviewProps) {
             />
           ) : (
             <Text textAlign="center" color="gray.500" p="2rem">
-              Loading questions...
+              {t("extractionForm.loading")}
             </Text>
           )
         ) : (
@@ -72,12 +74,11 @@ export default function ExtractionForm({ studyData }: ArticlePreviewProps) {
               <Icon as={LockIcon} w={6} h={6} color="gray.400" />
               <VStack spacing={1}>
                 <Text fontSize="md" fontWeight="bold" color="gray.800">
-                  Extraction Disabled
+                  {t("extractionFormDisabled.title")}
                 </Text>
                 <Text fontSize="sm" color="gray.600">
-                  This study is currently marked as{" "}
-                  <strong>{studyData.extractionStatus}</strong>. Extraction is
-                  only allowed for included studies.
+                  {t("extractionFormDisabled.text1")}{" "}
+                  <strong>{t(`extractionFormDisabled.${studyData.extractionStatus}`)}</strong>. {t("extractionFormDisabled.text2")}
                 </Text>
               </VStack>
             </Flex>

--- a/src/features/review/planning-protocol/components/common/tables/InteractiveTable/index.tsx
+++ b/src/features/review/planning-protocol/components/common/tables/InteractiveTable/index.tsx
@@ -103,20 +103,20 @@ export default function InteractiveTable({ id, url, label }: Props) {
             let questions;
             switch (item.questionType) {
               case "TEXTUAL":
-                type = "textual";
+                type = t("selectionAndExtraction.input.extractionQuestions.questionType.textual");
                 break;
               case "PICK_LIST":
-                type = "pick list";
+                type = t("selectionAndExtraction.input.extractionQuestions.questionType.pickList");
                 questions = item.options;
                 break;
               case "NUMBERED_SCALE":
-                type = "number scale";
+                type = t("selectionAndExtraction.input.extractionQuestions.questionType.numberedScale");
                 break;
               case "LABELED_SCALE":
-                type = "labeled list";
+                type = t("selectionAndExtraction.input.extractionQuestions.questionType.labeledList");
                 break;
               case "PICK_MANY":
-                type = "pick many";
+                type = t("selectionAndExtraction.input.extractionQuestions.questionType.pickMany");
                 questions = item.options;
                 break;
             }
@@ -185,30 +185,30 @@ export default function InteractiveTable({ id, url, label }: Props) {
     let newQuestionId: string | null = null;
 
     try {
-      if (type === "textual") {
+      if (type === t("selectionAndExtraction.input.extractionQuestions.questionType.textual")) {
         questionType = "TEXTUAL";
         data = { question, questionId, reviewId };
         if (isNew) newQuestionId = await sendTextualQuestion(data);
         else await updateTextualQuestion(data, serverId, questionType);
-      } else if (type === "pick list") {
+      } else if (type === t("selectionAndExtraction.input.extractionQuestions.questionType.pickList")) {
         questionType = "PICK_LIST";
         data = { question, questionId, reviewId, options: questions };
         handleAddQuestions(index, questions);
         if (isNew) newQuestionId = await sendPickListQuestion(data);
         else await updatePickListQuestion(data, serverId, questionType);
-      } else if (type === "number scale") {
+      } else if (type === t("selectionAndExtraction.input.extractionQuestions.questionType.numberedScale")) {
         questionType = "NUMBERED_SCALE";
         data = { question, questionId, reviewId, lower: numberScale[0], higher: numberScale[1] };
         handleNumberScale(index, numberScale[0], numberScale[1]);
         if (isNew) newQuestionId = await sendNumberScaleQuestion(data);
         else await updateNumberScaleQuestion(data, serverId);
-      } else if (type === "labeled list") {
+      } else if (type === t("selectionAndExtraction.input.extractionQuestions.questionType.labeledList")) {
         questionType = "LABELED_SCALE";
         data = { question, questionId, reviewId, scales: labeledQuestions };
         handleLabeledList(index, labeledQuestions);
         if (isNew) newQuestionId = await sendLabeledListQuestion(data);
         else await updateLabeledListQuestion(data, serverId);
-      } else if (type === "pick many") {
+      } else if (type === t("selectionAndExtraction.input.extractionQuestions.questionType.pickMany")) {
         questionType = "PICK_MANY";
         data = { question, questionId, reviewId, options: pickManyQuestions };
         handlePickMany(index, pickManyQuestions);
@@ -374,7 +374,7 @@ export default function InteractiveTable({ id, url, label }: Props) {
           >
             {options.map((opt, i) => (
               <option key={i} value={opt.toLowerCase()}>
-                {opt}
+                {opt.charAt(0).toUpperCase() + opt.slice(1)}
               </option>
             ))}
           </Select>
@@ -450,7 +450,7 @@ export default function InteractiveTable({ id, url, label }: Props) {
         />
       </div>
 
-      {showModal && modalType === "pick list" && (
+      {showModal && modalType === t("selectionAndExtraction.input.extractionQuestions.questionType.pickList") && (
         <PickListModal
           show={setShowModal}
           questionHolder={setQuestions}
@@ -461,7 +461,7 @@ export default function InteractiveTable({ id, url, label }: Props) {
         />
       )}
 
-      {showModal && modalType === "number scale" && (
+      {showModal && modalType === t("selectionAndExtraction.input.extractionQuestions.questionType.numberedScale") && (
         <NumberScaleModal
           show={setShowModal}
           scaleHolder={setnumberScale}
@@ -472,7 +472,7 @@ export default function InteractiveTable({ id, url, label }: Props) {
         />
       )}
 
-      {showModal && modalType === "labeled list" && (
+      {showModal && modalType === t("selectionAndExtraction.input.extractionQuestions.questionType.labeledList") && (
         <LabeledScaleModal
           show={setShowModal}
           questionHolder={setLabeledQuestions}
@@ -483,7 +483,7 @@ export default function InteractiveTable({ id, url, label }: Props) {
         />
       )}
 
-      {showModal && modalType === "pick many" && (
+      {showModal && modalType === t("selectionAndExtraction.input.extractionQuestions.questionType.pickMany") && (
         <PickManyModal
           show={setShowModal}
           optionHolder={setPickManyQuestions}

--- a/src/features/review/planning-protocol/components/common/tables/InteractiveTable/index.tsx
+++ b/src/features/review/planning-protocol/components/common/tables/InteractiveTable/index.tsx
@@ -154,8 +154,8 @@ export default function InteractiveTable({ id, url, label }: Props) {
 
     if (String(rows[index].id).trim() === "") {
       toaster({
-        title: "A reference code is required.",
-        description: "Please fill in the Code field before saving.",
+        title: t("selectionAndExtraction.input.extractionQuestions.toaster.referenceCode.title"),
+        description: t("selectionAndExtraction.input.extractionQuestions.toaster.referenceCode.description"),
         status: "warning",
       });
       return;
@@ -168,8 +168,8 @@ export default function InteractiveTable({ id, url, label }: Props) {
 
     if (currentCode !== "" && isDuplicate) {
       toaster({
-        title: `The reference code '${currentCode}' is already in use.`,
-        description: "Please choose another one.",
+        title: t("selectionAndExtraction.input.extractionQuestions.toaster.duplicated.title1") + ` ${currentCode} ` + t("selectionAndExtraction.input.extractionQuestions.toaster.duplicated.title2"),
+        description: t("selectionAndExtraction.input.extractionQuestions.toaster.duplicated.description"),
         status: "error",
       });
       return;
@@ -280,7 +280,7 @@ export default function InteractiveTable({ id, url, label }: Props) {
   function addNewRow() {
     if (editIndex !== null) {
       toaster({
-        title: "Finish editing the current row before adding a new one.",
+        title: t("selectionAndExtraction.input.extractionQuestions.toaster.finishEditing"),
         status: "warning",
       });
       return;

--- a/src/features/review/planning-protocol/hooks/useInteractiveTable.ts
+++ b/src/features/review/planning-protocol/hooks/useInteractiveTable.ts
@@ -1,4 +1,5 @@
 import { SetStateAction, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 export interface Row {
   isNew: boolean;
@@ -13,8 +14,16 @@ export interface Row {
 }
 
 export function useInteractiveTable() {
+  const { t } = useTranslation("review/planning-protocol");
   const [rows, setRows] = useState<Row[]>([]);
-  const options = ["", "Textual", "Pick list", "Number scale", "Labeled List", "Pick many"];
+  const options = [
+    "",
+    t("selectionAndExtraction.input.extractionQuestions.questionType.textual"),
+    t("selectionAndExtraction.input.extractionQuestions.questionType.pickList"),
+    t("selectionAndExtraction.input.extractionQuestions.questionType.numberedScale"),
+    t("selectionAndExtraction.input.extractionQuestions.questionType.labeledList"),
+    t("selectionAndExtraction.input.extractionQuestions.questionType.pickMany")
+  ];
   const headers = ["Id", "Question", "Type", ""];
 
   const addRow = (setEditIndex: React.Dispatch<SetStateAction<number | null>>, setQuestions: React.Dispatch<SetStateAction<string[]>>) => {

--- a/src/locales/en/review/execution-extraction.json
+++ b/src/locales/en/review/execution-extraction.json
@@ -9,6 +9,18 @@
         "text2": "Extraction is only allowed for included studies."
     },
     "extractionForm": {
-        "loading": "Loading questions..."
+        "loading": "Loading questions...",
+        "noQuestions": "No questions found",
+        "createQuestions": "Create Questions",
+        "requiredField": "* This field is required",
+        "submit": "Submit",
+        "dropdownList": "Options",
+        "labeledList": "Labels",
+        "clearSelection": "Clear Selection",
+        "textual": "Your response",
+        "noChangesToast": {
+            "title": "No changes made",
+            "description": "Update at least one answer before submitting."
+        }
     }
 }

--- a/src/locales/en/review/execution-extraction.json
+++ b/src/locales/en/review/execution-extraction.json
@@ -6,6 +6,7 @@
         "text1": "This study is currently marked as",
         "EXCLUDED": "EXCLUDED",
         "UNCLASSIFIED": "UNCLASSIFIED",
+        "DUPLICATED": "DUPLICATED",
         "text2": "Extraction is only allowed for included studies."
     },
     "extractionForm": {

--- a/src/locales/en/review/execution-extraction.json
+++ b/src/locales/en/review/execution-extraction.json
@@ -1,4 +1,14 @@
 {
     "header": "Extraction",
-    "search": "Insert article attribute"
+    "search": "Insert article attribute",
+    "extractionFormDisabled": {
+        "title": "Extraction Disabled",
+        "text1": "This study is currently marked as",
+        "EXCLUDED": "EXCLUDED",
+        "UNCLASSIFIED": "UNCLASSIFIED",
+        "text2": "Extraction is only allowed for included studies."
+    },
+    "extractionForm": {
+        "loading": "Loading questions..."
+    }
 }

--- a/src/locales/en/review/planning-protocol.json
+++ b/src/locales/en/review/planning-protocol.json
@@ -156,7 +156,14 @@
                 "label": "Extraction Questions",
                 "question": "QUESTION",
                 "type": "TYPE",
-                "noDataFound": "No data found"
+                "noDataFound": "No data found",
+                "questionType": {
+                    "textual": "textual",
+                    "pickList": "pick list",
+                    "numberedScale": "number scale", 
+                    "labeledList": "labeled list",
+                    "pickMany": "pick many"
+                }
             }
         }
     },

--- a/src/locales/en/review/planning-protocol.json
+++ b/src/locales/en/review/planning-protocol.json
@@ -163,6 +163,18 @@
                     "numberedScale": "number scale", 
                     "labeledList": "labeled list",
                     "pickMany": "pick many"
+                },
+                "toaster": {
+                    "referenceCode": {
+                        "title": "A reference code is required.",
+                        "description": "Please fill in the Code field before saving."
+                    },
+                    "duplicated": {
+                        "title1": "The reference code",
+                        "title2": "is already in use.",
+                        "description": "Please choose another one."
+                    },
+                    "finishEditing": "Finish editing the current row before adding a new one."
                 }
             }
         }

--- a/src/locales/pt/review/execution-extraction.json
+++ b/src/locales/pt/review/execution-extraction.json
@@ -20,7 +20,7 @@
         "textual": "Sua resposta",
         "noChangesToast": {
             "title": "Nenhuma mudança foi feita",
-            "description": "Atualize pelo menos uma questão antes antes de reenviar."
+            "description": "Atualize pelo menos uma resposta antes antes de reenviar."
         }
     }
 }

--- a/src/locales/pt/review/execution-extraction.json
+++ b/src/locales/pt/review/execution-extraction.json
@@ -9,7 +9,7 @@
         "text2": "Extração só é permitida para estudos incluídos."
     },
     "extractionForm": {
-        "loading": "Carregand questões...",
+        "loading": "Carregando questões...",
         "noQuestions": "Nenhuma questão foi encontrada",
         "createQuestions": "Criar Questões",
         "requiredField": "* Esse campo é obrigatório",

--- a/src/locales/pt/review/execution-extraction.json
+++ b/src/locales/pt/review/execution-extraction.json
@@ -9,6 +9,18 @@
         "text2": "Extração só é permitida para estudos incluídos."
     },
     "extractionForm": {
-        "loading": "Carregand questões..."
+        "loading": "Carregand questões...",
+        "noQuestions": "Nenhuma questão foi encontrada",
+        "createQuestions": "Criar Questões",
+        "requiredField": "* Esse campo é obrigatório",
+        "submit": "Enviar",
+        "dropdownList": "Opções",
+        "labeledList": "Descrições",
+        "clearSelection": "Limpar seleção",
+        "textual": "Sua resposta",
+        "noChangesToast": {
+            "title": "Nenhuma mudança foi feita",
+            "description": "Atualize pelo menos uma questão antes antes de reenviar."
+        }
     }
 }

--- a/src/locales/pt/review/execution-extraction.json
+++ b/src/locales/pt/review/execution-extraction.json
@@ -1,4 +1,14 @@
 {
     "header": "Extração",
-    "search": "Inserir atributo do artigo"
+    "search": "Inserir atributo do artigo",
+    "extractionFormDisabled": {
+        "title": "Extração Desabilitada",
+        "text1": "Esse estudo está marcado como",
+        "EXCLUDED": "EXCLUÍDO",
+        "UNCLASSIFIED": "NÃO CLASSIFICADO",
+        "text2": "Extração só é permitida para estudos incluídos."
+    },
+    "extractionForm": {
+        "loading": "Carregand questões..."
+    }
 }

--- a/src/locales/pt/review/execution-extraction.json
+++ b/src/locales/pt/review/execution-extraction.json
@@ -6,6 +6,7 @@
         "text1": "Esse estudo está marcado como",
         "EXCLUDED": "EXCLUÍDO",
         "UNCLASSIFIED": "NÃO CLASSIFICADO",
+        "DUPLICATED": "DUPLICADO",
         "text2": "Extração só é permitida para estudos incluídos."
     },
     "extractionForm": {

--- a/src/locales/pt/review/planning-protocol.json
+++ b/src/locales/pt/review/planning-protocol.json
@@ -156,7 +156,14 @@
                 "label": "Questões de Extração",
                 "question": "QUESTÃO",
                 "type": "TIPO",
-                "noDataFound": "Dados não encontrados"
+                "noDataFound": "Dados não encontrados",
+                "questionType": {
+                    "textual": "textual",
+                    "pickList": "seleção única",
+                    "numberedScale": "escala numérica",
+                    "labeledList": "lista rotulada",
+                    "pickMany": "seleção múltipla"
+                }
             }
         }
     },

--- a/src/locales/pt/review/planning-protocol.json
+++ b/src/locales/pt/review/planning-protocol.json
@@ -163,6 +163,18 @@
                     "numberedScale": "escala numérica",
                     "labeledList": "lista rotulada",
                     "pickMany": "seleção múltipla"
+                },
+                "toaster": {
+                    "referenceCode": {
+                        "title": "Um código de referência é obrigatório.",
+                        "description": "Por favor, preencha o campo de código de referência antes de salvar."
+                    },
+                    "duplicated": {
+                        "title1": "O código de referência",
+                        "title2": "já está sendo usado.",
+                        "description": "Por favor, escolha outro."
+                    },
+                    "finishEditing": "Termine de editar a linha atual antes de adicionar uma nova."
                 }
             }
         }


### PR DESCRIPTION
## Summary

This PR adds internationalization support to the question type field in the Risk of Bias and Extraction questions tables, the Extraction form disabled warning, placeholders and buttons. 

It also adds translation support for toast/toaster messages in the "Selection and Extraction" page and the "Extraction" page.

---

## Changes

### i18n Configuration
- Adds new translation fields to the `planning-protocol` and `execution-extraction` translation JSON files

### UI Updates
- Adds translations for question types in the RoB and Extraction questions tables
- Adds translations for the disabled warning message, labels, placeholders, and buttons in the Extraction form
- Adds translation support for toast/toaster messages
- Adjusts component logic to properly handle translated values

---

## Screenshots

### Question type selection translated to Portuguese
<img width="1056" height="532" alt="Captura de tela 2026-05-11 104540" src="https://github.com/user-attachments/assets/97a549e4-54ec-48df-8346-26398e92389c" />

### Disabled warning message in the Extraction form
<img width="453" height="445" alt="Captura de tela 2026-05-11 104605" src="https://github.com/user-attachments/assets/3be64460-278d-4da7-9700-ca04b107070a" />
