### PR TITLE
GM-fix-duplicated-articles

### DIFF
--- a/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
+++ b/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
@@ -122,6 +122,7 @@ export default function ButtonsForSelection({
 
   const isInclusionActive = criteriaOptions.INCLUSION.isActive;
   const isExclusionActive = criteriaOptions.EXCLUSION.isActive;
+  const isDuplicated = currentArticle.extractionStatus === "DUPLICATED" || currentArticle.selectionStatus === "DUPLICATED";
   const isUniqueArticle = articles.length === 1;
 
   async function goToNextArticle() {
@@ -176,13 +177,13 @@ export default function ButtonsForSelection({
     INCLUSION: {
       label: "Include",
       description: "Add inclusion criteria",
-      isDisabled: criteriaGroupDataMap["INCLUSION"].data.length === 0 || isExclusionActive,
+      isDisabled: criteriaGroupDataMap["INCLUSION"].data.length === 0 || isExclusionActive || isDuplicated,
       options: criteriaGroupDataMap["INCLUSION"].data,
     },
     EXCLUSION: {
       label: "Exclude",
       description: "Add exclusion criteria",
-      isDisabled: criteriaGroupDataMap["EXCLUSION"].data.length === 0 || isInclusionActive,
+      isDisabled: criteriaGroupDataMap["EXCLUSION"].data.length === 0 || isInclusionActive || isDuplicated,
       options: criteriaGroupDataMap["EXCLUSION"].data,
     },
   };


### PR DESCRIPTION
## Changes
Prevent adding inclusion/exclusion criteria to duplicated articles by introducing a boolean variable `isDuplicated`. Inclusion/exclusion criteria can only be added when this variable is false.

## Screenshot
### View of a duplicated article
<img width="466" height="612" alt="Captura de tela 2026-05-11 131405" src="https://github.com/user-attachments/assets/2ab08631-14d7-4776-af0e-d2af48fb3127" />
