### PR TITLE
fix: remove stale cache guard and revalidate included-studies-answers SWR key after question save/delete

### DIFF
--- a/src/features/review/execution-extraction/services/useFetchAllQuestionsByArticle.ts
+++ b/src/features/review/execution-extraction/services/useFetchAllQuestionsByArticle.ts
@@ -80,48 +80,42 @@ export default function useFetchAllQuestionsByArticle() {
   useEffect(() => {
     if (!question) return;
 
-    setArticlesStructureAnswers((prev) => {
-      if (prev[articleId]) return prev;
+    const mapToStructure = (questions: QuestionAnswer[]): AnswerStrucuture[] =>
+      questions.map((quest) => {
+        let formattedAnswer = quest.answer;
 
-      const mapToStructure = (
-        questions: QuestionAnswer[],
-      ): AnswerStrucuture[] =>
-        questions.map((quest) => {
-          let formattedAnswer = quest.answer;
+        if (quest.type === "LABELED_SCALE" && quest.answer) {
+          formattedAnswer = formatLabel(quest.answer as string);
+        }
 
-          if (quest.type === "LABELED_SCALE" && quest.answer) {
-            formattedAnswer = formatLabel(quest.answer as string);
-          }
+        if (
+          quest.type === "PICK_MANY" &&
+          quest.answer &&
+          typeof quest.answer != "number"
+        ) {
+          formattedAnswer = formatAnswer(quest.answer);
+        }
 
-          if (
-            quest.type === "PICK_MANY" &&
-            quest.answer &&
-            typeof quest.answer != "number"
-          ) {
-            formattedAnswer = formatAnswer(quest.answer);
-          }
+        return {
+          questionId: quest.questionId,
+          description: quest.description,
+          code: quest.code,
+          type: quest.type,
+          answer: {
+            value: formattedAnswer,
+          },
+        };
+      });
 
-          return {
-            questionId: quest.questionId,
-            description: quest.description,
-            code: quest.code,
-            type: quest.type,
-            answer: {
-              value: formattedAnswer,
-            },
-          };
-        });
+    const structuredAnswers: ArticleAnswerStrucuture = {
+      extractionQuestions: mapToStructure(question.extractionQuestions),
+      robQuestions: mapToStructure(question.robQuestions),
+    };
 
-      const structuredAnswers: ArticleAnswerStrucuture = {
-        extractionQuestions: mapToStructure(question.extractionQuestions),
-        robQuestions: mapToStructure(question.robQuestions),
-      };
-
-      return {
-        ...prev,
-        [articleId]: structuredAnswers,
-      };
-    });
+    setArticlesStructureAnswers((prev) => ({
+      ...prev,
+      [articleId]: structuredAnswers,
+    }));
   }, [question, articleId]);
 
   return {

--- a/src/features/review/planning-protocol/components/common/tables/InteractiveTable/index.tsx
+++ b/src/features/review/planning-protocol/components/common/tables/InteractiveTable/index.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import { Input, Select, FormLabel, Textarea } from "@chakra-ui/react";
+import { mutate } from "swr";
+import { useTranslation } from "react-i18next";
 import Axios from "../../../../../../../infrastructure/http/axiosClient";
 import EventButton from "@components/common/buttons/EventButton";
 
@@ -17,7 +19,6 @@ import PickManyModal from "../../modals/PickManyModal";
 import LabeledScaleModal from "../../modals/LabeledScaleModal";
 import useValidatorSQLInjection from "@features/shared/hooks/useValidatorSQLInjection";
 import useToaster from "@components/feedback/Toaster";
-import { useTranslation } from "react-i18next";
 
 interface Props {
   id: string;
@@ -29,6 +30,8 @@ export default function InteractiveTable({ id, url, label }: Props) {
   let adress = "";
   if (label == "Extraction Questions" || label == "Questões de Extração") adress = "extraction-question";
   if (label == "Risk of Bias Questions" || label == "Questões sobre Risco de Viés") adress = "rob-question";
+
+  const protocolKey = `systematic-study/${id}/protocol/${adress}`;
 
   const toaster = useToaster();
   const validator = useValidatorSQLInjection();
@@ -149,6 +152,17 @@ export default function InteractiveTable({ id, url, label }: Props) {
     }
   }
 
+  async function revalidateFormulary() {
+    await mutate(protocolKey);
+
+    await mutate(
+      (key: string) =>
+        typeof key === "string" &&
+        key.includes(`systematic-study/${id}/report/`) &&
+        key.includes("/included-studies-answers"),
+    );
+  }
+
   async function handleSaveEdit(index: number, closeEditMode: boolean = true) {
     if (!validator({ value: rows[index].question })) return;
 
@@ -220,9 +234,7 @@ export default function InteractiveTable({ id, url, label }: Props) {
         handleServerSend(index, newQuestionId);
       }
 
-      const accessToken = localStorage.getItem("accessToken");
-      let optionsReq = { headers: { Authorization: `Bearer ${accessToken}` } };
-      await Axios.get(`systematic-study/${id}/protocol/extraction-question`, optionsReq);
+      await revalidateFormulary();
 
       if (closeEditMode) {
         setEditIndex(null);
@@ -252,6 +264,8 @@ export default function InteractiveTable({ id, url, label }: Props) {
 
       await deleteQuestion(data as any, serverId);
       handleDelete(index);
+
+      await revalidateFormulary();
 
       if (pendingNewIndex === index) {
         setPendingNewIndex(null);
@@ -455,9 +469,7 @@ export default function InteractiveTable({ id, url, label }: Props) {
           show={setShowModal}
           questionHolder={setQuestions}
           questions={questions}
-          onSave={() => {
-            if (editIndex !== null) handleSaveEdit(editIndex, false);
-          }}
+          onSave={() => {}}
         />
       )}
 
@@ -466,9 +478,7 @@ export default function InteractiveTable({ id, url, label }: Props) {
           show={setShowModal}
           scaleHolder={setnumberScale}
           values={numberScale}
-          onSave={() => {
-            if (editIndex !== null) handleSaveEdit(editIndex, false);
-          }}
+          onSave={() => {}}
         />
       )}
 
@@ -477,9 +487,7 @@ export default function InteractiveTable({ id, url, label }: Props) {
           show={setShowModal}
           questionHolder={setLabeledQuestions}
           questions={labeledQuestions}
-          onSave={() => {
-            if (editIndex !== null) handleSaveEdit(editIndex, false);
-          }}
+          onSave={() => {}}
         />
       )}
 
@@ -488,9 +496,7 @@ export default function InteractiveTable({ id, url, label }: Props) {
           show={setShowModal}
           optionHolder={setPickManyQuestions}
           options={pickManyQuestions}
-          onSave={() => {
-            if (editIndex !== null) handleSaveEdit(editIndex, false);
-          }}
+          onSave={() => {}}
         />
       )}
     </div>


### PR DESCRIPTION
### Correção: novas perguntas não apareciam no formulário de extração quando já estava aberto
- O formulário de extração não atualizava ao adicionar novas perguntas em Extraction Questions ou RoB Questions porque o hook useFetchAllQuestionsByArticle ignorava dados novos do SWR quando o artigo já havia sido carregado uma vez. Além disso, o InteractiveTable invalidava apenas a chave do protocolo, mas o formulário consome a chave included-studies-answers, que nunca era revalidada. A correção remove o guard de cache e passa a invalidar ambas as chaves SWR após cada save ou delete.