### PR TITLE
fix: display custom code instead of default codes

### DIFF
--- a/src/features/review/shared/components/common/menu/ComboBox/index.tsx
+++ b/src/features/review/shared/components/common/menu/ComboBox/index.tsx
@@ -151,6 +151,10 @@ export default function ComboBox({
           const isHighlighted =
             page === "Extraction" && selectedCriteria.includes(option.text);
 
+            const hasColon = option.text.includes(":");
+            const code = hasColon ? option.text.substring(0, option.text.indexOf(":")).trim() : null;
+            const desc = hasColon ? option.text.substring(option.text.indexOf(":") + 1).trim() : option.text;
+
           return (
             <MenuItem key={index} maxW="25rem" overflow="auto">
               {text === "Include" ? (
@@ -160,7 +164,7 @@ export default function ComboBox({
                   onChange={(e) => handleCheckboxToggle(e, option.text)}
                 >
                   <Tooltip
-                    label={option.text}
+                    label={desc}
                     aria-label="Full criteria"
                     p="1rem"
                     hasArrow
@@ -171,7 +175,7 @@ export default function ComboBox({
                       fontWeight={isHighlighted ? "bold" : "normal"}
                       color={isHighlighted ? "black" : "inherit"}
                     >
-                      {`IC-${(index + 1).toString().padStart(2, "0")}`}
+                      {code || `IC-${(index + 1).toString().padStart(2, "0")}`}
                     </Text>
                   </Tooltip>
                 </Checkbox>
@@ -182,7 +186,7 @@ export default function ComboBox({
                   onChange={(e) => handleCheckboxToggle(e, option.text)}
                 >
                   <Tooltip
-                    label={option.text}
+                    label={desc}
                     aria-label="Full criteria"
                     p="1rem"
                     hasArrow
@@ -193,7 +197,7 @@ export default function ComboBox({
                       fontWeight={isHighlighted ? "bold" : "normal"}
                       color={isHighlighted ? "black" : "inherit"}
                     >
-                      {`EC-${(index + 1).toString().padStart(2, "0")}`}
+                      {code || `EC-${(index + 1).toString().padStart(2, "0")}`}
                     </Text>
                   </Tooltip>
                 </Checkbox>


### PR DESCRIPTION
### Corrigir a exibição dos critérios para que utilizem o código customizado definido em Criteria, em vez do padrão fixo (IC01, EC01, etc.)

- Na hora de selecionar os critérios de exclusão ou inclusão, os códigos que apareciam não eram os códigos definidos na criação do critério. Se eu criasse um critério chamado IC-07, mas fosse o IC-04, apareceria como IC-04, e o nome customizado apareceria como um tooltip.

- Por exemplo, coloquei o nome do quarto critério de inclusão, de IC-50:

### Antes
<img width="230" height="220" alt="image" src="https://github.com/user-attachments/assets/c6148c50-2dcc-4ce4-998a-d25064887209" />


### Depois
<img width="235" height="217" alt="image" src="https://github.com/user-attachments/assets/5a327f7a-61c6-4745-97c1-ed0e02eb8a61" />

### Local da Alteração
<img width="227" height="930" alt="image" src="https://github.com/user-attachments/assets/a82fb056-e4c2-4f10-b8df-6b3fe59de5f5" />