### PR TITLE
GM-feat-graphics-table-column-filter

### DIFF
--- a/src/features/review/shared/components/common/menu/ColumnVisibilityMenu/index.tsx
+++ b/src/features/review/shared/components/common/menu/ColumnVisibilityMenu/index.tsx
@@ -17,7 +17,7 @@ type ColumnVisibilityMenuInput = {
 import styles from "./styles.module.css";
 
 const columnLabels: {
-  [K in keyof Omit<ColumnVisibility, "studyReviewId">]: string;
+  [K in keyof Omit<ColumnVisibility, "studyReviewId" | "source" | "answer">]: string;
 } = {
   title: "Title",
   authors: "Author",
@@ -27,6 +27,16 @@ const columnLabels: {
   extractionStatus: "Extraction",
   score: "Score",
   readingPriority: "Priority",
+  included: "Included",
+  excluded: "Excluded",
+  total: "Total",
+  indexingRate: "IndexingRate",
+  precisionRate: "PrecisionRate",
+  sources: "Sources",
+  ic: "IC",
+  studies: "Studies",
+  totalAnswers: "TotalAnswers",
+  percentageOfTotal: "PercentageOfTotal",
 };
 
 // Animations

--- a/src/features/review/shared/components/common/menu/ColumnVisibilityMenu/index.tsx
+++ b/src/features/review/shared/components/common/menu/ColumnVisibilityMenu/index.tsx
@@ -105,7 +105,7 @@ export default function ColumnVisibilityMenu({
                       toggleColumnVisibility(key as keyof ColumnVisibility)
                     }
                   />
-                  <span style={{ marginLeft: 8 }}>{t(`columnVisibilityMenu.label.${label.toLowerCase()}`)}</span>
+                  <span>{t(`columnVisibilityMenu.label.${label.toLowerCase()}`)}</span>
                 </label>
               ))}
           </motion.div>

--- a/src/features/review/shared/components/structure/LayoutFactory/index.tsx
+++ b/src/features/review/shared/components/structure/LayoutFactory/index.tsx
@@ -18,7 +18,7 @@ import { PaginationControls } from "@features/shared/types/pagination";
 import { KeyedMutator } from "swr";
 import { SelectionArticles } from "@features/review/execution-selection/services/useFetchSelectionArticles";
 
-export type PageLayout = "Selection" | "Extraction" | "Identification";
+export type PageLayout = "Selection" | "Extraction" | "Identification" | "Graphics-SearchSources" | "Graphics-IncludedStudies" | "Graphics-FormQuestions";
 
 interface LayoutFactoryProps {
   layout: ViewModel;

--- a/src/features/review/shared/hooks/useVisibilityColumns.ts
+++ b/src/features/review/shared/hooks/useVisibilityColumns.ts
@@ -5,15 +5,27 @@ import { useMemo, useState } from "react";
 import { PageLayout } from "../components/structure/LayoutFactory";
 
 export type ColumnVisibility = {
-  studyReviewId: boolean;
-  title: boolean;
-  authors: boolean;
-  venue: boolean;
-  year: boolean;
+  studyReviewId: boolean | null;
+  title: boolean | null;
+  authors: boolean | null;
+  venue: boolean | null;
+  year: boolean | null;
   selectionStatus: boolean | null;
   extractionStatus: boolean | null;
-  score: boolean;
-  readingPriority: boolean;
+  score: boolean | null;
+  readingPriority: boolean | null;
+  source: boolean | null;
+  included: boolean | null;
+  excluded: boolean | null;
+  total: boolean | null;
+  indexingRate: boolean | null;
+  precisionRate: boolean | null;
+  sources: boolean | null;
+  ic: boolean | null;
+  answer: boolean | null;
+  studies: boolean | null;
+  totalAnswers: boolean | null;
+  percentageOfTotal: boolean | null;
 };
 
 type UseVisibilityColumnsInput = {
@@ -36,6 +48,18 @@ const defaultVisibility: ColumnVisibility = {
   extractionStatus: true,
   score: true,
   readingPriority: true,
+  source: true,
+  included: true,
+  excluded: true,
+  total: true,
+  indexingRate: true,
+  precisionRate: true,
+  sources: true,
+  ic: true,
+  answer: true,
+  studies: true,
+  totalAnswers: true,
+  percentageOfTotal: true,
 };
 
 export default function useVisibiltyColumns({
@@ -45,15 +69,103 @@ export default function useVisibiltyColumns({
     const visibility = { ...defaultVisibility };
     if (page === "Selection") {
       visibility.extractionStatus = null;
+      visibility.source = null;
+      visibility.included = null;
+      visibility.excluded = null;
+      visibility.total = null;
+      visibility.indexingRate = null;
+      visibility.precisionRate = null;
+      visibility.sources = null;
+      visibility.ic = null;
+      visibility.answer = null;
+      visibility.studies = null;
+      visibility.totalAnswers = null;
+      visibility.percentageOfTotal = null;
     }
     if (page === "Extraction") {
       visibility.selectionStatus = null;
+      visibility.source = null;
+      visibility.included = null;
+      visibility.excluded = null;
+      visibility.total = null;
+      visibility.indexingRate = null;
+      visibility.precisionRate = null;
+      visibility.sources = null;
+      visibility.ic = null;
+      visibility.answer = null;
+      visibility.studies = null;
+      visibility.totalAnswers = null;
+      visibility.percentageOfTotal = null;
     }
     if (page === "Identification"){
       visibility.selectionStatus = null;
       visibility.extractionStatus = null;
       visibility.score = false;
       visibility.readingPriority = false;
+      visibility.source = null;
+      visibility.included = null;
+      visibility.excluded = null;
+      visibility.total = null;
+      visibility.indexingRate = null;
+      visibility.precisionRate = null;
+      visibility.sources = null;
+      visibility.ic = null;
+      visibility.answer = null;
+      visibility.studies = null;
+      visibility.totalAnswers = null;
+      visibility.percentageOfTotal = null;
+    }
+    if (page === "Graphics-SearchSources"){
+      visibility.studyReviewId = null;
+      visibility.title = null;
+      visibility.authors = null;
+      visibility.venue = null;
+      visibility.year = null;
+      visibility.selectionStatus = null;
+      visibility.extractionStatus = null;
+      visibility.score = null;
+      visibility.readingPriority = null;
+      visibility.sources = null;
+      visibility.ic = null;
+      visibility.answer = null;
+      visibility.studies = null;
+      visibility.totalAnswers = null;
+      visibility.percentageOfTotal = null;
+    }
+    if (page === "Graphics-IncludedStudies") {
+      visibility.selectionStatus = null;
+      visibility.extractionStatus = null;
+      visibility.source = null;
+      visibility.included = null;
+      visibility.excluded = null;
+      visibility.total = null;
+      visibility.indexingRate = null;
+      visibility.precisionRate = null;
+      visibility.score = null;
+      visibility.readingPriority = null;
+      visibility.answer = null;
+      visibility.studies = null;
+      visibility.totalAnswers = null;
+      visibility.percentageOfTotal = null;
+    }
+    if (page === "Graphics-FormQuestions") {
+      visibility.studyReviewId = null;
+      visibility.title = null;
+      visibility.authors = null;
+      visibility.venue = null;
+      visibility.year = null;
+      visibility.selectionStatus = null;
+      visibility.extractionStatus = null;
+      visibility.score = null;
+      visibility.readingPriority = null;
+      visibility.source = null;
+      visibility.included = null;
+      visibility.excluded = null;
+      visibility.total = null;
+      visibility.indexingRate = null;
+      visibility.precisionRate = null;
+      visibility.sources = null;
+      visibility.ic = null;
     }
     return visibility;
   }, [page]);

--- a/src/features/review/shared/hooks/useVisibilityColumns.ts
+++ b/src/features/review/shared/hooks/useVisibilityColumns.ts
@@ -1,5 +1,5 @@
 // External library
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 
 // Types
 import { PageLayout } from "../components/structure/LayoutFactory";
@@ -172,6 +172,10 @@ export default function useVisibiltyColumns({
 
   const [columnsVisible, setColumnsVisible] =
     useState<ColumnVisibility>(initialVisibility);
+
+  useEffect(() => {
+    setColumnsVisible(initialVisibility);
+  }, [initialVisibility]);
 
   const toggleColumnVisibility = (column: keyof ColumnVisibility) => {
     setColumnsVisible((prev) => ({

--- a/src/features/review/summarization-graphics/components/layout/ChartFullTable/index.tsx
+++ b/src/features/review/summarization-graphics/components/layout/ChartFullTable/index.tsx
@@ -6,17 +6,20 @@ import { Box } from "@chakra-ui/react";
 
 import ChartTable from "../../tables/ChartTable";
 import ArticleInterface from "@features/review/shared/types/ArticleInterface";
+import { ColumnVisibility } from "@features/review/shared/hooks/useVisibilityColumns";
 
 interface TableProps {
   articles:  ArticleInterface [];
+  columnsVisible: ColumnVisibility;
 }
 
 export const ChartFullTable: React.FC<TableProps> = ({
   articles,
+  columnsVisible,
 }) => {
   return (
     <Box w="100%" h="100%">
-      <ChartTable articles={articles}  />
+      <ChartTable columnsVisible={columnsVisible} articles={articles}  />
     </Box>
   );
 };

--- a/src/features/review/summarization-graphics/components/tables/ChartTable/ChartExpanded/index.tsx
+++ b/src/features/review/summarization-graphics/components/tables/ChartTable/ChartExpanded/index.tsx
@@ -35,6 +35,7 @@ import { Resizable } from "@features/review/shared/components/common/tables/Arti
 import useFetchInclusionCriteria from "@features/review/shared/services/useFetchInclusionCriteria";
 import { StudyInterface } from "@features/review/shared/types/IStudy";
 import { useExport } from "@features/review/summarization-graphics/context/ExportContext";
+import { ColumnVisibility } from "@features/review/shared/hooks/useVisibilityColumns";
 
 export type AllKeys =
   | "studyReviewId"
@@ -51,6 +52,7 @@ interface Props {
   handleHeaderClick: (key: AllKeys) => void;
   sortConfig: { key: AllKeys; direction: "asc" | "desc" } | null;
   layout?: ViewModel;
+  columnsVisible: ColumnVisibility;
 }
 
 type Column = {
@@ -64,6 +66,7 @@ export default function ChartExpanded({
   handleHeaderClick,
   sortConfig,
   layout,
+  columnsVisible
 }: Props) {
   const [columnWidths, setColumnWidths] = useState({
     studyReviewId: "56px",
@@ -103,6 +106,15 @@ export default function ChartExpanded({
     },
     { key: "ic", label: "IC", width: columnWidths.ic },
   ];
+
+  const visibleColumns = columns.filter((column) => {
+    const visibilityKey =
+      column.key === "searchSources"
+        ? "sources"
+        : column.key;
+
+    return columnsVisible[visibilityKey as keyof ColumnVisibility] === true;
+  });
 
   const collapsedSpanTextChanged = {
     ...collapsedSpanText,
@@ -209,7 +221,7 @@ export default function ChartExpanded({
             borderBottom=".5rem solid #C9D9E5"
           >
             <Tr>
-              {columns.map((col) => (
+              {visibleColumns.map((col) => (
                 <Th
                   key={col.key}
                   textAlign="center"
@@ -321,7 +333,7 @@ export default function ChartExpanded({
 
                 return (
                   <Tr key={index} bg="transparent" p="0">
-                    {columns.map((col) => {
+                    {visibleColumns.map((col) => {
                       let value: string | number = "";
 
                       switch (col.key) {
@@ -381,7 +393,7 @@ export default function ChartExpanded({
               })
             ) : (
               <Tr>
-                <Td colSpan={columns.length + 1} textAlign="center">
+                <Td colSpan={visibleColumns.length + 1} textAlign="center">
                   No articles found.
                 </Td>
               </Tr>

--- a/src/features/review/summarization-graphics/components/tables/ChartTable/LayoutFactoryChart/index.tsx
+++ b/src/features/review/summarization-graphics/components/tables/ChartTable/LayoutFactoryChart/index.tsx
@@ -9,20 +9,23 @@ import { ChartFullTable } from "../../../layout/ChartFullTable";
 
 import ArticleInterface from "@features/review/shared/types/ArticleInterface";
 import NoDataMessage from "@features/review/shared/components/structure/NoDataMessage";
+import { ColumnVisibility } from "@features/review/shared/hooks/useVisibilityColumns";
 
 interface LayoutFactoryProps {
   articles: ArticleInterface[] ;
   isLoading: boolean;
+  columnsVisible: ColumnVisibility;
 }
 
 export default function LayoutFactoryChart({
   articles,
   isLoading,
+  columnsVisible,
 }: LayoutFactoryProps) {
   return isLoading ? (
     <SkeletonLoader width="100%" height="100%" />
   ) : articles && articles.length > 0 ? (
-    <ChartFullTable articles={articles} />
+    <ChartFullTable columnsVisible={columnsVisible} articles={articles} />
   ) : (
     <NoDataMessage/>
   );

--- a/src/features/review/summarization-graphics/components/tables/ChartTable/index.tsx
+++ b/src/features/review/summarization-graphics/components/tables/ChartTable/index.tsx
@@ -3,13 +3,15 @@ import { useMemo, useState } from "react";
 import type ArticleInterface from "@features/review/shared/types/ArticleInterface";
 import type { ViewModel } from "@features/review/shared/hooks/useLayoutPage";
 import ChartExpanded, { AllKeys } from "./ChartExpanded";
+import { ColumnVisibility } from "@features/review/shared/hooks/useVisibilityColumns";
 
 interface Props {
   articles: ArticleInterface[];
   layout?: ViewModel;
+  columnsVisible: ColumnVisibility;
 }
 
-export default function ChartTable({ articles, layout }: Props) {
+export default function ChartTable({ articles, layout, columnsVisible }: Props) {
   const [sortConfig, setSortConfig] = useState<{
     key: AllKeys;
     direction: "asc" | "desc";
@@ -57,6 +59,7 @@ export default function ChartTable({ articles, layout }: Props) {
       handleHeaderClick={handleHeaderClick}
       sortConfig={sortConfig}
       layout={layout}
+      columnsVisible={columnsVisible}
     />
   );
 }

--- a/src/features/review/summarization-graphics/components/tables/QuestionsTable/index.tsx
+++ b/src/features/review/summarization-graphics/components/tables/QuestionsTable/index.tsx
@@ -1,3 +1,4 @@
+import { ColumnVisibility } from "@features/review/shared/hooks/useVisibilityColumns";
 import { ColumnDef, GenericExpandedTable } from "../ChartTable/GenericExpandedTable";
 
 import { useTranslation } from "react-i18next";
@@ -11,9 +12,10 @@ type QuestionRow = {
 
 interface QuestionsTableProps {
   data: Record<string, number[]>;
+  columnsVisible: ColumnVisibility;
 }
 
-export const QuestionsTable = ({ data }: QuestionsTableProps) => {
+export const QuestionsTable = ({ data, columnsVisible }: QuestionsTableProps) => {
   const { t } = useTranslation("review/summarization-graphics");
 
   const totalResponses = Object.values(data).reduce((sum, ids) => sum + ids.length, 0);
@@ -35,6 +37,16 @@ const columns: ColumnDef<QuestionRow>[] = [
   { key: "percentage", label: t("questionsTable.percentage"), width: 100, isNumeric: true, sortable: true, render: (row) => row.percentage.toFixed(2) + "%" },
 ];
 
+const visibleColumns = columns.filter((column) => {
+  const visibilityKey =
+    column.key === "total"
+      ? "totalAnswers"
+      : column.key === "percentage"
+      ? "percentageOfTotal"
+      : column.key;
 
-  return <GenericExpandedTable<QuestionRow> data={rows} columns={columns} />;
+  return columnsVisible[visibilityKey as keyof ColumnVisibility] === true;
+});
+
+  return <GenericExpandedTable<QuestionRow> data={rows} columns={visibleColumns} />;
 };

--- a/src/features/review/summarization-graphics/components/tables/SearchSoucesTable/index.tsx
+++ b/src/features/review/summarization-graphics/components/tables/SearchSoucesTable/index.tsx
@@ -8,6 +8,7 @@ import { fetchStudiesBySource, HttpResponse } from "@features/review/summarizati
 import useGetAllReviewArticles from "@features/review/shared/services/useGetAllReviewArticles";
 import useFetchDataBases from "@features/review/shared/services/useFetchDataBases";
 import { ColumnDef, GenericExpandedTable } from "../ChartTable/GenericExpandedTable";
+import { ColumnVisibility } from "@features/review/shared/hooks/useVisibilityColumns";
 
 
 type SearchSourceRow = {
@@ -25,7 +26,7 @@ type Description = {
   total: number;
 };
 
-export const SearchSorcesTable = () => {
+export const SearchSorcesTable = ({ columnsVisible }: {columnsVisible: ColumnVisibility}) => {
   const { t } = useTranslation("review/summarization-graphics");
   const { databases } = useFetchDataBases();
   const { articles } = useGetAllReviewArticles();
@@ -106,5 +107,9 @@ export const SearchSorcesTable = () => {
     { key: "precisionRate", label: t("searchSourcesTable.precisionRate"), width: 120, isNumeric: true, sortable: true, render: (row) => row.precisionRate.toFixed(2) + "%" },
   ];
 
-  return <GenericExpandedTable<SearchSourceRow> data={rows} columns={columns}/>;
+  const visibleColumns = columns.filter((column) => {
+    return columnsVisible[column.key as keyof ColumnVisibility];
+  });
+  
+  return <GenericExpandedTable<SearchSourceRow> data={rows} columns={visibleColumns}/>;
 };

--- a/src/features/review/summarization-graphics/pages/Graphics/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/index.tsx
@@ -59,7 +59,7 @@ export default function Graphics() {
     "Included Studies": "Graphics-IncludedStudies",
     "Form Questions": "Graphics-FormQuestions",
   }
-  
+
   useEffect(() => {
     const tableSelected = tableMap[section] ?? null;
     if(tableSelected) setTablePage(tableSelected);
@@ -124,6 +124,7 @@ export default function Graphics() {
               type={type}
               filters={filters}
               selectedQuestionId={selectedQuestionId}
+              columnsVisible={columnsVisible}
             />
           ) : (
             <Flex direction="column" align="center" justify="center" h="800px" textAlign="center">

--- a/src/features/review/summarization-graphics/pages/Graphics/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/index.tsx
@@ -13,6 +13,8 @@ import { useFetchExtractionQuestions } from "@features/review/execution-extracti
 import { useFetchRobQuestions } from "@features/review/execution-extraction/services/useFetchRobQuestions";
 import ColumnVisibilityMenu from "@features/review/shared/components/common/menu/ColumnVisibilityMenu";
 import useVisibiltyColumns from "@features/review/shared/hooks/useVisibilityColumns";
+import { PageLayout } from "@features/review/shared/components/structure/LayoutFactory";
+import { useState, useEffect } from "react";
 
 export default function Graphics() {
   const {
@@ -32,6 +34,8 @@ export default function Graphics() {
   const { questions: extractionQuestions = [] } = useFetchExtractionQuestions();
   const { questions: robQuestions = [] } = useFetchRobQuestions();
 
+  const [tablePage, setTablePage] = useState<PageLayout>("Graphics-SearchSources");
+
   const { t } = useTranslation("review/summarization-graphics");
 
   const handleUnifiedSelection = (value: string) => {
@@ -47,9 +51,20 @@ export default function Graphics() {
   };
 
   const { columnsVisible, toggleColumnVisibility } = useVisibiltyColumns({
-    page: "Graphics-FormQuestions",
+    page: tablePage,
   });
 
+  const tableMap: Record<string, PageLayout | null> = {
+    "Search Sources": "Graphics-SearchSources",
+    "Included Studies": "Graphics-IncludedStudies",
+    "Form Questions": "Graphics-FormQuestions",
+  }
+  
+  useEffect(() => {
+    const tableSelected = tableMap[section] ?? null;
+    if(tableSelected) setTablePage(tableSelected);
+  }, [section]);
+  
   return (
     <FlexLayout navigationType="Accordion">
       <Flex justifyContent="space-between" alignItems="flex-start" w="100%" mb="1rem">

--- a/src/features/review/summarization-graphics/pages/Graphics/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/index.tsx
@@ -11,6 +11,8 @@ import { ExportProvider } from "../../context/ExportContext";
 import { useTranslation } from "react-i18next";
 import { useFetchExtractionQuestions } from "@features/review/execution-extraction/services/useFetchExtractionQuestions";
 import { useFetchRobQuestions } from "@features/review/execution-extraction/services/useFetchRobQuestions";
+import ColumnVisibilityMenu from "@features/review/shared/components/common/menu/ColumnVisibilityMenu";
+import useVisibiltyColumns from "@features/review/shared/hooks/useVisibilityColumns";
 
 export default function Graphics() {
   const {
@@ -44,9 +46,9 @@ export default function Graphics() {
     }
   };
 
-  // const { columnsVisible, toggleColumnVisibility } = useVisibiltyColumns({
-  //   page: "Selection",
-  // });
+  const { columnsVisible, toggleColumnVisibility } = useVisibiltyColumns({
+    page: "Graphics-FormQuestions",
+  });
 
   return (
     <FlexLayout navigationType="Accordion">
@@ -68,26 +70,33 @@ export default function Graphics() {
           )}
         </Flex>
 
-        <Flex flexDirection="column" gap="0.5rem" mt="0.75rem">
-          <SectionMenu
-            onSelect={handleUnifiedSelection}
-            selected={selectedQuestionId || section}
-            extractionQuestions={extractionQuestions.filter(q => q.questionId !== null)}
-            robQuestions={robQuestions.filter(q => q.questionId !== null)}
-          />
-
-          {section && !(
-            section === "Studies Funnel" ||
-            section === "Form Questions" ||
-            section === "Protocol"
-          ) && (
-            <SelectMenu
-              options={currentAllowedTypes}
-              selected={type}
-              onSelect={setType}
-              placeholder={t("selectMenu.chooseLayout")}
+        <Flex gap="0.5rem" mt="0.75rem" alignItems={section === "Form Questions" ? "flex-start" : "flex-end"}>
+          {type === t("selectMenu.graphicsTypes.table") && (
+            <ColumnVisibilityMenu
+              columnsVisible={columnsVisible}
+              toggleColumnVisibility={toggleColumnVisibility}
             />
           )}
+          <Flex flexDirection="column" gap="0.5rem">
+            <SectionMenu
+              onSelect={handleUnifiedSelection}
+              selected={selectedQuestionId || section}
+              extractionQuestions={extractionQuestions.filter(q => q.questionId !== null)}
+              robQuestions={robQuestions.filter(q => q.questionId !== null)}
+            />
+            {section && !(
+              section === "Studies Funnel" ||
+              section === "Form Questions" ||
+              section === "Protocol"
+            ) && (
+              <SelectMenu
+                options={currentAllowedTypes}
+                selected={type}
+                onSelect={setType}
+                placeholder={t("selectMenu.chooseLayout")}
+              />
+            )}
+          </Flex>
         </Flex>
       </Flex>
 

--- a/src/features/review/summarization-graphics/pages/Graphics/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/index.tsx
@@ -44,6 +44,10 @@ export default function Graphics() {
     }
   };
 
+  // const { columnsVisible, toggleColumnVisibility } = useVisibiltyColumns({
+  //   page: "Selection",
+  // });
+
   return (
     <FlexLayout navigationType="Accordion">
       <Flex justifyContent="space-between" alignItems="flex-start" w="100%" mb="1rem">

--- a/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/FormQuestionsRenderer/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/FormQuestionsRenderer/index.tsx
@@ -3,13 +3,14 @@ import { Box } from "@chakra-ui/react";
 import { QuestionsCharts } from "../../QuestionsCharts";
 import ArticleInterface from "@features/review/shared/types/ArticleInterface";
 import { StudyInterface } from "@features/review/shared/types/IStudy";
+import { ColumnVisibility } from "@features/review/shared/hooks/useVisibilityColumns";
 
 type Props = {
   filteredStudies: (StudyInterface | ArticleInterface)[];
   type: string;
   chartId: string;
   selectedQuestionId?: string;
-
+  columnsVisible: ColumnVisibility;
 };
 
 export default function FormQuestionsRenderer({
@@ -17,7 +18,7 @@ export default function FormQuestionsRenderer({
   type,
   selectedQuestionId,
   chartId,
-
+  columnsVisible
 }: Props) {
   return (
     <Box id={chartId}>
@@ -25,7 +26,7 @@ export default function FormQuestionsRenderer({
         filteredStudies={filteredStudies as ArticleInterface[]}
         type={type}
         selectedQuestionId={selectedQuestionId}
-     
+        columnsVisible={columnsVisible}
       />
     </Box>
   );

--- a/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/IncludedStudiesRenderer/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/IncludedStudiesRenderer/index.tsx
@@ -6,22 +6,24 @@ import BubbleChart from "@features/review/summarization-graphics/components/char
 import useBubbleDataGeneric, { BubbleItem } from "@features/review/summarization-graphics/hooks/useBubbleDataGeneric";
 import { Box } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { ColumnVisibility } from "@features/review/shared/hooks/useVisibilityColumns";
 
 
 type Props = {
   filteredStudies: (StudyInterface | ArticleInterface)[];
   type: string;
   chartId: string;
+  columnsVisible: ColumnVisibility;
 };
 
-export default function IncludedStudiesRenderer({ filteredStudies, type, chartId}: Props) {
+export default function IncludedStudiesRenderer({ filteredStudies, type, chartId, columnsVisible}: Props) {
   const { t } = useTranslation("review/summarization-graphics");
   const includedStudies = filteredStudies.filter((s) => s.extractionStatus === "INCLUDED");
 
 
 
   let content;
-  if (type === "Table" || type === "Tabela") content = <LayoutFactoryChart articles={includedStudies as ArticleInterface[]} isLoading={false} />;
+  if (type === "Table" || type === "Tabela") content = <LayoutFactoryChart columnsVisible={columnsVisible} articles={includedStudies as ArticleInterface[]} isLoading={false} />;
   else if (type === "Line Chart" || type === "Gráfico de Linhas") content = <IncludedStudiesLineChart filteredStudies={includedStudies} />;
   else if (type === "Bubble Chart" || type === "Gráfico de Bolhas") {
     const items: BubbleItem[] = includedStudies.flatMap(study => 

--- a/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/SearchSourcesRenderer/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/SearchSourcesRenderer/index.tsx
@@ -14,17 +14,20 @@ import useBubbleDataGeneric, {
 } from "@features/review/summarization-graphics/hooks/useBubbleDataGeneric";
 
 import { barchartBox } from "../../../styles";
+import { ColumnVisibility } from "@features/review/shared/hooks/useVisibilityColumns";
 
 type Props = {
   filteredStudies: (StudyInterface | ArticleInterface)[];
   type: string;
   chartId: string;
+  columnsVisible: ColumnVisibility;
 };
 
 export default function SearchSourcesRenderer({
   filteredStudies,
   type,
   chartId,
+  columnsVisible,
 }: Props) {
   const { t } = useTranslation("review/summarization-graphics");
   const sourceCountMap = filteredStudies.reduce<Record<string, number>>(
@@ -72,7 +75,7 @@ export default function SearchSourcesRenderer({
       />
     );
   } else if (type === "Table" || type === "Tabela") {
-    content = <SearchSorcesTable />;
+    content = <SearchSorcesTable columnsVisible={columnsVisible} />;
   } else {
     content = <div>{t("typeNotSupported")}</div>;
   }

--- a/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/index.tsx
@@ -148,6 +148,7 @@ export default function ChartsRenderer({
         {...props}
         chartId={chartId}
         selectedQuestionId={selectedQuestionId}
+        columnsVisible={columnsVisible}
       />
     ),
     "Studies Funnel": () => <StudiesFunnelRenderer chartId={chartId} />,

--- a/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/index.tsx
@@ -109,7 +109,7 @@ export default function ChartsRenderer({
       <SearchSourcesRenderer {...props} columnsVisible={columnsVisible} chartId={chartId} />
     ),
     "Included Studies": (props: any) => (
-      <IncludedStudiesRenderer {...props} chartId={chartId} />
+      <IncludedStudiesRenderer {...props} columnsVisible={columnsVisible} chartId={chartId} />
     ),
     "S1_Inclusion Criteria": (props: any) => (
       <CriteriaRenderer

--- a/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/index.tsx
@@ -19,12 +19,14 @@ import { buildQuestionsCsv } from "@features/review/summarization-graphics/compo
 import ArticleInterface from "@features/review/shared/types/ArticleInterface";
 import { useFetchStudiesByStage } from "@features/review/summarization-graphics/services/useFetchStudiesByStage";
 import useFetchStudiesByCriteria from "@features/review/summarization-graphics/services/useFetchStudiesByCriteria";
+import { ColumnVisibility } from "@features/review/shared/hooks/useVisibilityColumns";
 
 type Props = {
   section: string;
   type: string;
   filters: FiltersState;
   selectedQuestionId?: string;
+  columnsVisible: ColumnVisibility
 };
 export type CsvRow = Record<string, string | number>;
 
@@ -33,6 +35,7 @@ export default function ChartsRenderer({
   type,
   filters,
   selectedQuestionId,
+  columnsVisible
 }: Props) {
   const { articles, isLoading } = useGetAllReviewArticles();
   const [, setCsvData] = useState<CsvRow[]>([]);
@@ -103,7 +106,7 @@ export default function ChartsRenderer({
   // Map de renderers
   const rendererMap: Record<string, any> = {
     "Search Sources": (props: any) => (
-      <SearchSourcesRenderer {...props} chartId={chartId} />
+      <SearchSourcesRenderer {...props} columnsVisible={columnsVisible} chartId={chartId} />
     ),
     "Included Studies": (props: any) => (
       <IncludedStudiesRenderer {...props} chartId={chartId} />

--- a/src/features/review/summarization-graphics/pages/Graphics/subcomponents/QuestionsCharts/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/subcomponents/QuestionsCharts/index.tsx
@@ -4,11 +4,13 @@ import BarChart from "../../../../components/charts/BarChart";
 import { QuestionsTable } from "../../../../components/tables/QuestionsTable";
 import useFetchQuestionAnswers from "../../../../services/useFetchQuestionAnwers";
 import ArticleInterface from "@features/review/shared/types/ArticleInterface";
+import { ColumnVisibility } from "@features/review/shared/hooks/useVisibilityColumns";
 
 type Props = {
   selectedQuestionId?: string;
   filteredStudies: ArticleInterface[];
   type: string;
+  columnsVisible: ColumnVisibility
 };
 
 type Question = {
@@ -82,6 +84,7 @@ export const QuestionsCharts = ({
   selectedQuestionId,
   filteredStudies,
   type,
+  columnsVisible
 }: Props) => {
   const { extractionAnswers, isLoadingExtractionAnswers } =
     useFetchQuestionAnswers();
@@ -144,7 +147,7 @@ export const QuestionsCharts = ({
             />
           );
         } else {
-          chartContent = <QuestionsTable data={filteredAnswer} />;
+          chartContent = <QuestionsTable columnsVisible={columnsVisible} data={filteredAnswer} />;
         }
 
         return (

--- a/src/locales/en/review/execution-selection.json
+++ b/src/locales/en/review/execution-selection.json
@@ -29,7 +29,17 @@
             "selection": "Selection",
             "extraction": "Extraction",
             "score": "Score",
-            "priority": "Priority"
+            "priority": "Priority",
+            "included": "Included",
+            "excluded": "Excluded",
+            "total": "Total",
+            "indexingrate": "Indexing Rate",
+            "precisionrate": "Precision Rate",
+            "sources": "Sources",
+            "ic": "IC",
+            "studies": "Studies",
+            "totalanswers": "Total",
+            "percentageoftotal": "Percentage"
         }
     },
     "statusSelect": {

--- a/src/locales/pt/review/execution-selection.json
+++ b/src/locales/pt/review/execution-selection.json
@@ -29,7 +29,17 @@
             "selection": "Seleção",
             "extraction": "Extração",
             "score": "Pontuação",
-            "priority": "Prioridade"
+            "priority": "Prioridade",
+            "included": "Incluídos",
+            "excluded": "Excluídos",
+            "total": "Total",
+            "indexingrate": "Taxa de Indexação",
+            "precisionrate": "Taxa de Precisão",
+            "sources": "Fontes",
+            "ic": "IC",
+            "studies": "Estudos",
+            "totalanswers": "Total",
+            "percentageoftotal": "Porcentagem"
         }
     },
     "statusSelect": {


### PR DESCRIPTION
# Summary

This PR adds column visibility filtering support to the Graphics page tables.

Previously, the column visibility menu was statically bound to a single table layout (Selection and Extraction), causing filtering options to not update dynamically when the user switched between different sections of the Graphics page.

This update makes the column visibility system dynamic, allowing the filtering options to adapt according to the currently selected table type.

It also applies internationalization to the filtering options

---

# Changes

## Column Visibility Infrastructure

* Adds new `PageLayout` types for Graphics tables
* Extends the `useVisibilityColumns` hook to support Graphics page table layouts
* Adds synchronization of the column visibility state when the selected Graphics page section changes
* Adds dynamic mapping between Graphics sections and their corresponding table layouts

## Graphics Page Updates

* Adds the `ColumnVisibilityMenu` to the Graphics page
* Adds internationalization support for the new view/filter options

## Table Filtering Support

Adds column visibility filtering support to:

* Search Sources table
* Included Studies table
* Questions table

## Component Updates

* Propagates `columnsVisible` state through Graphics renderers and table components
* Filters rendered columns dynamically based on the current visibility configuration

---

# Screenshots

## Search Sources Table


### Full table

<img width="1536" height="730" alt="search-sources" src="https://github.com/user-attachments/assets/c80619a8-4f32-416e-8ac5-34fbb86f8eb5" />


### Example of Filtered Table

<img width="1536" height="732" alt="search-sources-after" src="https://github.com/user-attachments/assets/56839cc5-c24c-4bb2-b62f-84b48a552810" />

## Included Studies Table


### Full table

<img width="1536" height="730" alt="included-studies" src="https://github.com/user-attachments/assets/1b11446e-a80d-4b1b-bddc-e61bea18417b" />


### Example of Filtered table

<img width="1536" height="731" alt="included-studies-after" src="https://github.com/user-attachments/assets/8f15b81e-f61d-4c2e-bb55-4a2424a46722" />

## Form Questions Table


### Full table

<img width="1536" height="731" alt="form-questions" src="https://github.com/user-attachments/assets/3b76f824-8b31-4449-9cce-1e8ee6043955" />


### Example of Filtered table

<img width="1536" height="730" alt="form-questions-after" src="https://github.com/user-attachments/assets/b6e7b8e1-42aa-4f38-b25e-e7d5128928f8" />
