### PR TITLE
fix: redirect to login modal when session expires

### DIFF
--- a/src/features/auth/services/refresh.ts
+++ b/src/features/auth/services/refresh.ts
@@ -1,17 +1,22 @@
 // External library
-import { isAxiosError } from "axios";
-
-// Infra
-import Axios from "../../../infrastructure/http/axiosClient";
+import axios, { isAxiosError } from "axios";
 
 // Factory
 import errorFactory from "@features/shared/errors/factory/errorFactory";
 
 // Error
-import { type Either, right } from "@features/shared/errors/pattern/Either";
+import {
+  type Either,
+  right,
+} from "@features/shared/errors/pattern/Either";
+
 import { ApplicationError } from "@features/shared/errors/base/ApplicationError";
 
-// Types
+const RefreshAxios = axios.create({
+  baseURL: import.meta.env.VITE_PUBLIC_API_URL,
+  withCredentials: true,
+});
+
 type RefreshResponse = {
   accessToken: string;
 };
@@ -20,25 +25,24 @@ export default async function refresh(): Promise<
   Either<ApplicationError, RefreshResponse>
 > {
   try {
-    const { data: response } = await Axios.post<RefreshResponse>(
-      "auth/refresh",
-      {}
-    );
+    const { data } =
+      await RefreshAxios.post<RefreshResponse>(
+        "auth/refresh"
+      );
 
-    return right(response);
+    return right(data);
   } catch (error) {
     if (isAxiosError(error)) {
-      const message =
-        error.response?.data?.detail ||
+      return errorFactory(
+        "unauthorized",
         error.response?.data?.message ||
-        error.message;
-      return errorFactory("unauthorized", message);
+          error.message
+      );
     }
 
-    if (error instanceof Error) {
-      return errorFactory("custom", error.message);
-    }
-
-    return errorFactory("custom", "An unexpected error occurred.");
+    return errorFactory(
+      "custom",
+      "Unexpected refresh error."
+    );
   }
 }

--- a/src/features/auth/store/useAuthStore.ts
+++ b/src/features/auth/store/useAuthStore.ts
@@ -1,116 +1,299 @@
 // External library
 import { create } from "zustand";
-import { persist, createJSONStorage } from "zustand/middleware";
+
+import {
+  persist,
+  createJSONStorage,
+} from "zustand/middleware";
 
 // Hooks
 import useDecodeToken from "@features/auth/hooks/useDecodeToken";
 
 // Services
 import loginService from "@features/auth/services/login";
+
 import logoutService from "@features/auth/services/logout";
+
+import refresh from "@features/auth/services/refresh";
 
 // Factory
 import errorFactory from "@features/shared/errors/factory/errorFactory";
 
 // Error
 import type { Either } from "@features/shared/errors/pattern/Either";
+
 import { ApplicationError } from "@features/shared/errors/base/ApplicationError";
 
 // Guards
-import { isLeft, right } from "@features/shared/errors/pattern/Either";
+import {
+  isLeft,
+  right,
+} from "@features/shared/errors/pattern/Either";
 
 // Types
-import type { AccessCredentials, UserData } from "@features/auth/types";
+import type {
+  AccessCredentials,
+  UserData,
+} from "@features/auth/types";
 
-// Types
 interface AuthState {
   user: UserData | null;
+
   isLoading: boolean;
+
   login: (
     credentials: AccessCredentials
   ) => Promise<Either<ApplicationError, void>>;
+
   logout: () => Promise<void>;
+
   _hasHydrated: boolean;
+
   setHasHydrated: (value: boolean) => void;
+
   updateToken: (newToken: string) => void;
 }
 
-const { checkTokenExpiration, decodeToken } = useDecodeToken();
+const {
+  checkTokenExpiration,
+  decodeToken,
+} = useDecodeToken();
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set, get) => ({
-      user: null,
-      isLoading: true,
-      _hasHydrated: false,
+let refreshTimer: ReturnType<
+  typeof setTimeout
+> | null = null;
 
-      setHasHydrated: (value) => {
-        set({ _hasHydrated: value });
-      },
+function redirectToLogin() {
+  window.location.href =
+    "/?showModal=login";
+}
 
-      updateToken: (newToken: string) => {
-        const currentUser = get().user;
-        if (!currentUser) return;
-        set({
-          user: { ...currentUser, token: newToken },
-        });
-      },
+function scheduleRefresh(
+  token: string,
+  updateToken: (token: string) => void,
+  logout: () => Promise<void>
+) {
+  const decoded = decodeToken(token);
 
-      login: async (credentials) => {
-        set({ isLoading: true });
-        try {
-          const result = await loginService(credentials);
+  const expiresAt = decoded.exp * 1000;
 
-          if (isLeft(result)) {
-            return result;
-          }
+  const now = Date.now();
 
-          const { accessToken: token } = result.value;
-          const decoded = decodeToken(token);
+  const timeout = expiresAt - now;
 
-          if (!checkTokenExpiration(decoded)) {
-            return errorFactory("unauthorized", "Expires token.");
-          }
+  if (refreshTimer) {
+    clearTimeout(refreshTimer);
+  }
 
-          const { id, ...rest } = decoded;
-          const userData = { ...rest, token, id };
+  if (timeout <= 0) {
+    return;
+  }
 
-          set({ user: userData });
-          return right(undefined);
-        } catch (error) {
-          return errorFactory(
-            "custom",
-            "An unexpected error occurred in the login flow."
-          );
-        } finally {
-          set({ isLoading: false });
-        }
-      },
+  refreshTimer = setTimeout(async () => {
+    try {
+      const result = await refresh();
 
-      logout: async () => {
-        await logoutService();
-        set({ user: null });
-      },
-    }),
-    {
-      name: "auth-user-storage",
-      storage: createJSONStorage(() => localStorage),
-      partialize: (state) => ({ user: state.user }),
+      if (isLeft(result)) {
+        await logout();
 
-      onRehydrateStorage: () => (state) => {
+        redirectToLogin();
 
-        if (!state) {
-          useAuthStore.setState({ _hasHydrated: true, isLoading: false });
-          return;
-        }
-
-        useAuthStore.setState({
-          _hasHydrated: true,
-          isLoading: false,
-        });
+        return;
       }
-    }
-  )
-);
 
-useAuthStore.getState().setHasHydrated(true);
+      updateToken(result.value.accessToken);
+    } catch {
+      await logout();
+
+      redirectToLogin();
+    }
+  }, timeout);
+}
+
+export const useAuthStore =
+  create<AuthState>()(
+    persist(
+      (set, get) => ({
+        user: null,
+
+        isLoading: true,
+
+        _hasHydrated: false,
+
+        setHasHydrated: (value) => {
+          set({
+            _hasHydrated: value,
+          });
+        },
+
+        updateToken: (newToken: string) => {
+          const currentUser =
+            get().user;
+
+          if (!currentUser) return;
+
+          const decoded =
+            decodeToken(newToken);
+
+          scheduleRefresh(
+            newToken,
+            get().updateToken,
+            get().logout
+          );
+
+          set({
+            user: {
+              ...currentUser,
+              ...decoded,
+              token: newToken,
+            },
+          });
+        },
+
+        login: async (credentials) => {
+          set({
+            isLoading: true,
+          });
+
+          try {
+            const result =
+              await loginService(
+                credentials
+              );
+
+            if (isLeft(result)) {
+              return result;
+            }
+
+            const {
+              accessToken: token,
+            } = result.value;
+
+            const decoded =
+              decodeToken(token);
+
+            if (
+              !checkTokenExpiration(
+                decoded
+              )
+            ) {
+              return errorFactory(
+                "unauthorized",
+                "Expired token."
+              );
+            }
+
+            const { id, ...rest } =
+              decoded;
+
+            const userData = {
+              ...rest,
+              token,
+              id,
+            };
+
+            scheduleRefresh(
+              token,
+              get().updateToken,
+              get().logout
+            );
+
+            set({
+              user: userData,
+            });
+
+            return right(undefined);
+          } catch {
+            return errorFactory(
+              "custom",
+              "An unexpected error occurred in the login flow."
+            );
+          } finally {
+            set({
+              isLoading: false,
+            });
+          }
+        },
+
+        logout: async () => {
+          if (refreshTimer) {
+            clearTimeout(
+              refreshTimer
+            );
+
+            refreshTimer = null;
+          }
+
+          try {
+            await logoutService();
+          } finally {
+            set({
+              user: null,
+            });
+          }
+        },
+      }),
+      {
+        name: "auth-user-storage",
+
+        storage: createJSONStorage(
+          () => localStorage
+        ),
+
+        partialize: (state) => ({
+          user: state.user,
+        }),
+
+        onRehydrateStorage:
+          () => (state) => {
+            if (!state) {
+              useAuthStore.setState({
+                _hasHydrated: true,
+                isLoading: false,
+              });
+
+              return;
+            }
+
+            useAuthStore.setState({
+              _hasHydrated: true,
+              isLoading: false,
+            });
+
+            const user = state.user;
+
+            if (!user) return;
+
+            const decoded =
+              decodeToken(user.token);
+
+            if (
+              decoded.exp * 1000 <=
+              Date.now()
+            ) {
+              useAuthStore
+                .getState()
+                .logout();
+
+              redirectToLogin();
+
+              return;
+            }
+
+            scheduleRefresh(
+              user.token,
+              useAuthStore
+                .getState()
+                .updateToken,
+              useAuthStore
+                .getState()
+                .logout
+            );
+          },
+      }
+    )
+  );
+
+useAuthStore
+  .getState()
+  .setHasHydrated(true);

--- a/src/features/landing/pages/Homepage/subcomponents/Header/index.tsx
+++ b/src/features/landing/pages/Homepage/subcomponents/Header/index.tsx
@@ -1,19 +1,44 @@
 // External library
-import { useState } from "react";
+import {
+  useEffect,
+  useState,
+} from "react";
+
 import { Link } from "react-router-dom";
+
 import { Image } from "@chakra-ui/react";
-import { Menu, MenuButton, MenuList, MenuItem } from "@chakra-ui/react";
-import { Box, Button, Flex, Text } from "@chakra-ui/react";
+
+import {
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+} from "@chakra-ui/react";
+
+import {
+  Box,
+  Button,
+  Flex,
+  Text,
+} from "@chakra-ui/react";
+
 import { useTranslation } from "react-i18next";
+
 import i18n from "i18next";
+
 import ReactCountryFlag from "react-country-flag";
+
 import { ChevronDownIcon } from "@chakra-ui/icons";
 
 // Components
 import HomepageModal from "@features/landing/components/modals/HomepageModal/Index";
+
 import FormLogin from "@features/auth/components/forms/SignIn/Index";
+
 import FormSignup from "@features/auth/components/forms/Signup/Index";
+
 import ForgotPassword from "@features/auth/components/forms/ForgotPassword";
+
 import HeaderLink from "./subcomponents/links/HeaderLink";
 
 // Hooks
@@ -33,104 +58,233 @@ interface IHeaderProps {
   show: boolean;
 }
 
-type IModal = "" | "login" | "signup" | "forgotPassword";
+type IModal =
+  | ""
+  | "login"
+  | "signup"
+  | "forgotPassword";
 
 // Maps each i18n language code to its country code and label
 const languageOptions = [
-  { lang: "pt", countryCode: "BR", label: "PT" },
-  { lang: "en", countryCode: "US", label: "EN" },
+  {
+    lang: "pt",
+    countryCode: "BR",
+    label: "PT",
+  },
+
+  {
+    lang: "en",
+    countryCode: "US",
+    label: "EN",
+  },
 ];
 
-export default function Header({ show }: IHeaderProps) {
-  const { t } = useTranslation("landing/homepage");
+export default function Header({
+  show,
+}: IHeaderProps) {
+  const { t } = useTranslation(
+    "landing/homepage"
+  );
 
   enum LinkTypeEnum {
-    GoToOtherPage = "GoToOtherPage",
-    StayInSamePage = "StayInSamePage",
+    GoToOtherPage =
+      "GoToOtherPage",
+
+    StayInSamePage =
+      "StayInSamePage",
   }
 
   const showLinks = show;
-  const [showModal, setShowModal] = useState(false);
-  const [openModal, setOpenModal] = useState<IModal>("");
 
-  const { toGo } = useNavigation();
-  const { user, _hasHydrated } = useAuthStore();
+  const [showModal, setShowModal] =
+    useState(false);
+
+  const [openModal, setOpenModal] =
+    useState<IModal>("");
+
+  const { toGo } =
+    useNavigation();
+
+  const {
+    user,
+    _hasHydrated,
+  } = useAuthStore();
 
   const currentLanguage =
-    languageOptions.find((opt) => opt.lang === i18n.language) ??
-    languageOptions[0];
+    languageOptions.find(
+      (opt) =>
+        opt.lang ===
+        i18n.language
+    ) ?? languageOptions[0];
 
   function handleSignUpModal() {
     setOpenModal("signup");
+
     setShowModal(true);
   }
 
   function handleLoginModal() {
     setOpenModal("login");
+
     setShowModal(true);
   }
 
+  useEffect(() => {
+    const params =
+      new URLSearchParams(
+        window.location.search
+      );
+
+    const showModalParam =
+      params.get("showModal");
+
+    if (
+      showModalParam ===
+      "login"
+    ) {
+      setOpenModal("login");
+
+      setShowModal(true);
+
+      params.delete(
+        "showModal"
+      );
+
+      const newUrl =
+        window.location.pathname +
+        (params.toString()
+          ? `?${params.toString()}`
+          : "");
+
+      window.history.replaceState(
+        {},
+        "",
+        newUrl
+      );
+    }
+  }, []);
+
   return (
     <>
-      <HomepageModal show={showModal} onClose={() => setShowModal(false)}>
-        {openModal == "login" && (
+      <HomepageModal
+        show={showModal}
+        onClose={() =>
+          setShowModal(false)
+        }
+      >
+        {openModal ==
+          "login" && (
           <FormLogin
-            redirectForgotPassword={() => setOpenModal("forgotPassword")}
+            redirectForgotPassword={() =>
+              setOpenModal(
+                "forgotPassword"
+              )
+            }
           />
         )}
-        {openModal == "signup" && (
+
+        {openModal ==
+          "signup" && (
           <FormSignup
-            redirectFormLogin={() => setOpenModal("login")}
+            redirectFormLogin={() =>
+              setOpenModal(
+                "login"
+              )
+            }
             closeModal={() => {
               setOpenModal("");
+
               setShowModal(false);
             }}
           />
         )}
-        {openModal == "forgotPassword" && (
-          <ForgotPassword redirectFormLogin={() => setOpenModal("login")} />
+
+        {openModal ==
+          "forgotPassword" && (
+          <ForgotPassword
+            redirectFormLogin={() =>
+              setOpenModal(
+                "login"
+              )
+            }
+          />
         )}
       </HomepageModal>
 
       <Flex sx={HeaderTheme}>
-        <Flex width="auto" gap="10%" alignItems={"center"}>
+        <Flex
+          width="auto"
+          gap="10%"
+          alignItems={"center"}
+        >
           <Box>
             <Link to={"/"}>
-              <Image src={Logo} alt="Start Logo" />
+              <Image
+                src={Logo}
+                alt="Start Logo"
+              />
             </Link>
           </Box>
+
           {showLinks && (
             <Flex>
               <HeaderLink
-                text={t("header.about")}
+                text={t(
+                  "header.about"
+                )}
                 id={"sobre"}
-                type={LinkTypeEnum.StayInSamePage}
+                type={
+                  LinkTypeEnum.StayInSamePage
+                }
               />
+
               <HeaderLink
-                text={t("header.tutorials")}
+                text={t(
+                  "header.tutorials"
+                )}
                 id={"tutoriais"}
-                type={LinkTypeEnum.StayInSamePage}
+                type={
+                  LinkTypeEnum.StayInSamePage
+                }
               />
+
               <HeaderLink
-                text={t("header.collaborators")}
+                text={t(
+                  "header.collaborators"
+                )}
                 id={"colaboradores"}
-                type={LinkTypeEnum.StayInSamePage}
+                type={
+                  LinkTypeEnum.StayInSamePage
+                }
               />
+
               <HeaderLink
-                text={t("header.contact")}
+                text={t(
+                  "header.contact"
+                )}
                 id={"contato"}
-                type={LinkTypeEnum.StayInSamePage}
+                type={
+                  LinkTypeEnum.StayInSamePage
+                }
               />
+
               <HeaderLink
-                text={t("header.community")}
+                text={t(
+                  "header.community"
+                )}
                 id={"comuinidade"}
-                type={LinkTypeEnum.StayInSamePage}
+                type={
+                  LinkTypeEnum.StayInSamePage
+                }
               />
             </Flex>
           )}
         </Flex>
 
-        <Flex gap="5%" alignItems="center">
+        <Flex
+          gap="5%"
+          alignItems="center"
+        >
           {_hasHydrated && (
             <>
               <Menu>
@@ -138,95 +292,211 @@ export default function Header({ show }: IHeaderProps) {
                   as={Button}
                   color="white"
                   bg="transparent"
-                  _hover={{ color: "black", backgroundColor: "white" }}
-                  _active={{ color: "black", backgroundColor: "white" }}
-                  _expanded={{ color: "black", backgroundColor: "white" }}
+                  _hover={{
+                    color:
+                      "black",
+                    backgroundColor:
+                      "white",
+                  }}
+                  _active={{
+                    color:
+                      "black",
+                    backgroundColor:
+                      "white",
+                  }}
+                  _expanded={{
+                    color:
+                      "black",
+                    backgroundColor:
+                      "white",
+                  }}
                   px="0.75rem"
                 >
-                  <Flex alignItems="center" gap="0.4rem">
+                  <Flex
+                    alignItems="center"
+                    gap="0.4rem"
+                  >
                     <ReactCountryFlag
-                      countryCode={currentLanguage.countryCode}
+                      countryCode={
+                        currentLanguage.countryCode
+                      }
                       svg
                       style={{
-                        width: "1.2em",
-                        height: "1.2em",
-                        borderRadius: "2px",
+                        width:
+                          "1.2em",
+                        height:
+                          "1.2em",
+                        borderRadius:
+                          "2px",
                       }}
                     />
-                    <Text fontSize="sm" fontWeight="semibold">
-                      {currentLanguage.label}
+
+                    <Text
+                      fontSize="sm"
+                      fontWeight="semibold"
+                    >
+                      {
+                        currentLanguage.label
+                      }
                     </Text>
+
                     <ChevronDownIcon />
                   </Flex>
                 </MenuButton>
 
-                <MenuList minW="90px" w="90px">
-                  {languageOptions.map((opt) => (
-                    <MenuItem
-                      key={opt.lang}
-                      onClick={() => i18n.changeLanguage(opt.lang)}
-                      fontWeight={
-                        i18n.language === opt.lang ? "bold" : "normal"
-                      }
-                      color={i18n.language === opt.lang ? "#2E4B6C" : "inherit"}
-                    >
-                      <Flex alignItems="center" gap="0.5rem">
-                        <ReactCountryFlag
-                          countryCode={opt.countryCode}
-                          svg
-                          style={{
-                            width: "1.2em",
-                            height: "1.2em",
-                            borderRadius: "2px",
-                          }}
-                        />
-                        <Text fontSize="sm">{opt.label}</Text>
-                      </Flex>
-                    </MenuItem>
-                  ))}
+                <MenuList
+                  minW="90px"
+                  w="90px"
+                >
+                  {languageOptions.map(
+                    (opt) => (
+                      <MenuItem
+                        key={
+                          opt.lang
+                        }
+                        onClick={() =>
+                          i18n.changeLanguage(
+                            opt.lang
+                          )
+                        }
+                        fontWeight={
+                          i18n.language ===
+                          opt.lang
+                            ? "bold"
+                            : "normal"
+                        }
+                        color={
+                          i18n.language ===
+                          opt.lang
+                            ? "#2E4B6C"
+                            : "inherit"
+                        }
+                      >
+                        <Flex
+                          alignItems="center"
+                          gap="0.5rem"
+                        >
+                          <ReactCountryFlag
+                            countryCode={
+                              opt.countryCode
+                            }
+                            svg
+                            style={{
+                              width:
+                                "1.2em",
+                              height:
+                                "1.2em",
+                              borderRadius:
+                                "2px",
+                            }}
+                          />
+
+                          <Text fontSize="sm">
+                            {
+                              opt.label
+                            }
+                          </Text>
+                        </Flex>
+                      </MenuItem>
+                    )
+                  )}
                 </MenuList>
               </Menu>
 
               {user ? (
                 <Button
-                  _hover={{ color: "black", backgroundColor: "white" }}
-                  color={openModal == "login" && showModal ? "black" : "white"}
-                  bgColor={
-                    openModal == "login" && showModal ? "white" : "green"
+                  _hover={{
+                    color:
+                      "black",
+                    backgroundColor:
+                      "white",
+                  }}
+                  color={
+                    openModal ==
+                      "login" &&
+                    showModal
+                      ? "black"
+                      : "white"
                   }
-                  onClick={() => toGo("/home")}
+                  bgColor={
+                    openModal ==
+                      "login" &&
+                    showModal
+                      ? "white"
+                      : "green"
+                  }
+                  onClick={() =>
+                    toGo("/home")
+                  }
                 >
-                  {t("header.welcome", { name: user.sub })}
+                  {t(
+                    "header.welcome",
+                    {
+                      name:
+                        user.sub,
+                    }
+                  )}
                 </Button>
               ) : (
                 <>
                   <Button
-                    _hover={{ color: "black", backgroundColor: "white" }}
+                    _hover={{
+                      color:
+                        "black",
+                      backgroundColor:
+                        "white",
+                    }}
                     color={
-                      openModal == "signup" && showModal ? "black" : "white"
+                      openModal ==
+                        "signup" &&
+                      showModal
+                        ? "black"
+                        : "white"
                     }
                     bgColor={
-                      openModal == "signup" && showModal
+                      openModal ==
+                        "signup" &&
+                      showModal
                         ? "white"
                         : "rgba(0,0,0,0)"
                     }
-                    onClick={handleSignUpModal}
+                    onClick={
+                      handleSignUpModal
+                    }
                   >
-                    {t("header.signUp")}
+                    {t(
+                      "header.signUp"
+                    )}
                   </Button>
+
                   <Button
-                    _hover={{ color: "black", backgroundColor: "white" }}
+                    _hover={{
+                      color:
+                        "black",
+                      backgroundColor:
+                        "white",
+                    }}
                     color={
-                      openModal == "login" && showModal ? "black" : "white"
+                      openModal ==
+                        "login" &&
+                      showModal
+                        ? "black"
+                        : "white"
                     }
                     bgColor={
-                      openModal == "login" && showModal
+                      openModal ==
+                        "login" &&
+                      showModal
                         ? "white"
                         : "rgba(0,0,0,0)"
                     }
-                    onClick={handleLoginModal}
+                    onClick={
+                      handleLoginModal
+                    }
                   >
-                    {t("header.login")}
+                    {t(
+                      "header.login"
+                    )}
                   </Button>
                 </>
               )}

--- a/src/infrastructure/http/axiosClient.tsx
+++ b/src/infrastructure/http/axiosClient.tsx
@@ -1,5 +1,8 @@
 // External library
-import axios, { AxiosError, InternalAxiosRequestConfig } from "axios";
+import axios, {
+  AxiosError,
+  InternalAxiosRequestConfig,
+} from "axios";
 
 // Store
 import { useAuthStore } from "@features/auth/store/useAuthStore";
@@ -13,21 +16,29 @@ import { isLeft } from "@features/shared/errors/pattern/Either";
 const Axios = axios.create({
   baseURL: import.meta.env.VITE_PUBLIC_API_URL,
   withCredentials: true,
-  timeout: 100000,
 });
 
 let isRefreshing = false;
+
 let failedQueue: {
   resolve: (token: string) => void;
-  reject: (err: unknown) => void;
+  reject: (error: unknown) => void;
 }[] = [];
 
-const processQueue = (error: unknown, token: string | null = null) => {
-  failedQueue.forEach((prom) => {
+function redirectToLogin() {
+  window.location.href =
+    "/?showModal=login";
+}
+
+const processQueue = (
+  error: unknown,
+  token?: string
+) => {
+  failedQueue.forEach((promise) => {
     if (error) {
-      prom.reject(error);
+      promise.reject(error);
     } else if (token) {
-      prom.resolve(token);
+      promise.resolve(token);
     }
   });
 
@@ -35,94 +46,114 @@ const processQueue = (error: unknown, token: string | null = null) => {
 };
 
 Axios.interceptors.request.use(
-  (config: InternalAxiosRequestConfig) => {
-    const token = useAuthStore.getState().user?.token;
+  (
+    config: InternalAxiosRequestConfig
+  ) => {
+    const token =
+      useAuthStore.getState().user?.token;
 
     if (token) {
-      config.headers.set("Authorization", `Bearer ${token}`);
-    }
-
-    if (!(config.data instanceof FormData)) {
-      config.headers.set("Content-Type", "application/json");
+      config.headers.set(
+        "Authorization",
+        `Bearer ${token}`
+      );
     }
 
     return config;
-  },
-  (error: AxiosError) => Promise.reject(error)
+  }
 );
 
 Axios.interceptors.response.use(
-  (response) => {
-    return response;
-  },
+  (response) => response,
+
   async (error: AxiosError) => {
-    const originalRequest = error.config as InternalAxiosRequestConfig & {
-      _retry?: boolean;
-    };
+    const originalRequest =
+      error.config as InternalAxiosRequestConfig & {
+        _retry?: boolean;
+      };
 
-    const status = error.response?.status;
+    const status =
+      error.response?.status;
 
-    if (!error.response) {
-      return Promise.reject(error);
-    }
+    const user =
+      useAuthStore.getState().user;
 
-
-    if (originalRequest.url?.includes("auth/refresh")) {
-      useAuthStore.getState().logout();
-      window.location.href = "/login";
-      return Promise.reject(error);
-    }
-
-    const user = useAuthStore.getState().user;
-
-    if (status !== 401 || originalRequest._retry || !user) {
+    if (
+      status !== 401 ||
+      originalRequest._retry ||
+      !user
+    ) {
       return Promise.reject(error);
     }
 
     if (isRefreshing) {
-      return new Promise((resolve, reject) => {
-        failedQueue.push({
-          resolve: (token: string) => {
-            originalRequest.headers.set(
-              "Authorization",
-              `Bearer ${token}`
-            );
-            resolve(Axios(originalRequest));
-          },
-          reject,
-        });
-      });
+      return new Promise(
+        (resolve, reject) => {
+          failedQueue.push({
+            resolve: (
+              token: string
+            ) => {
+              originalRequest.headers.set(
+                "Authorization",
+                `Bearer ${token}`
+              );
+
+              resolve(
+                Axios(originalRequest)
+              );
+            },
+
+            reject,
+          });
+        }
+      );
     }
 
     originalRequest._retry = true;
+
     isRefreshing = true;
 
     try {
       const result = await refresh();
 
       if (isLeft(result)) {
-        processQueue(result.value, null);
-        useAuthStore.getState().logout();
-        window.location.href = "/login";
-        return Promise.reject(result.value);
+        processQueue(result.value);
+
+        await useAuthStore
+          .getState()
+          .logout();
+
+        redirectToLogin();
+
+        return Promise.reject(
+          result.value
+        );
       }
 
-      const { accessToken } = result.value;
+      const token =
+        result.value.accessToken;
 
-      useAuthStore.getState().updateToken(accessToken);
+      useAuthStore
+        .getState()
+        .updateToken(token);
 
-      processQueue(null, accessToken);
+      processQueue(null, token);
 
       originalRequest.headers.set(
         "Authorization",
-        `Bearer ${accessToken}`
+        `Bearer ${token}`
       );
 
       return Axios(originalRequest);
     } catch (err) {
-      processQueue(err, null);
-      useAuthStore.getState().logout();
-      window.location.href = "/login";
+      processQueue(err);
+
+      await useAuthStore
+        .getState()
+        .logout();
+
+      redirectToLogin();
+
       return Promise.reject(err);
     } finally {
       isRefreshing = false;


### PR DESCRIPTION
Esta PR ajusta o fluxo de expiração de sessão/autenticação para que o usuário seja redirecionado para a página inicial com o modal de login já aberto automaticamente.

Alterações realizadas:

  Adicionado suporte à query param `showModal=login` no `Header`
  Implementada abertura automática do modal de login via `useEffect`
  Ajustado fluxo de redirect após falha no refresh token
  Ajustado redirect após expiração do token salvo no storage
  Centralizado o redirect para login utilizando:
   `/?showModal=login`
  Mantido comportamento original visual do header e dos botões

 Fluxo esperado:

Quando o token expirar ou o refresh falhar:

1. Usuário é deslogado
2. Aplicação redireciona para:
   `/?showModal=login`
3. Modal de login é aberto automaticamente
4. Query param é removida da URL após abertura do modal
