### PR TITLE
GM-feat-internationalization-researchers

### DIFF
--- a/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/AddResearcher.tsx
+++ b/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/AddResearcher.tsx
@@ -1,8 +1,10 @@
+import { useTranslation } from "react-i18next";
 import { Flex, Input, Box, Avatar, Text } from "@chakra-ui/react";
 import { useEffect, useRef, useState } from "react";
 import EventButton from "@components/common/buttons/EventButton";
 
 export default function AddResearcher({researchers, setResearchers}:any) {
+  const { t } = useTranslation("review/planning-protocol"); 
   // Backend
   function filterSearch(search: string){
     return function (researcher:any){
@@ -84,7 +86,7 @@ export default function AddResearcher({researchers, setResearchers}:any) {
           ref={inputRef}
           style = {{ backgroundColor: chosenResearcherId !== "" ? "#C9D9E5" : "#ffffffff" }} flex="1" minW={0} size="md"  
           value={search} 
-          placeholder="Add a researcher" 
+          placeholder={t("generalDefinition.input.researchers.placeholder")} 
           onChange = {handleInputChange} 
           onFocus={() => setSuggestionsOpen(true)}
           onBlur={() => setSuggestionsOpen(false)}

--- a/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/AddResearcher.tsx
+++ b/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/AddResearcher.tsx
@@ -116,7 +116,7 @@ export default function AddResearcher({researchers, setResearchers}:any) {
                     </Flex>
                   ))
                 ) : (
-                  <Text color="gray.500" textAlign="center">No researchers found</Text>
+                  <Text color="gray.500" textAlign="center">{t("generalDefinition.input.researchers.noResearchersFound")}</Text>
                 )
             }
         </Box>

--- a/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/IncludedResearchers.tsx
+++ b/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/IncludedResearchers.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { ChevronDownIcon, DeleteIcon } from "@chakra-ui/icons";
 import { Avatar, Button, Flex, Icon, Menu, MenuButton, MenuItem, MenuList, Text } from "@chakra-ui/react";
 import { useState, useEffect } from "react";
@@ -5,6 +6,7 @@ import { useState, useEffect } from "react";
 const AVAILABLE_ROLES = ["admin", "reviewer", "owner"] as const;
 
 export default function IncludedResearchers({researchers, setResearchers}:any) {
+  const { t } = useTranslation("review/planning-protocol"); 
   // Backend
   function filterSearch(search: string){
     return function (researcher:any){
@@ -88,7 +90,7 @@ export default function IncludedResearchers({researchers, setResearchers}:any) {
           <Flex align="center" gap={5}>
             {(researcher.status === "pending" || researcher.status === "expired" || researcher.status === "excluding") && (
               <Text color="gray.500">
-                {researcher.status.charAt(0).toUpperCase() + researcher.status.slice(1)}
+                {t(`generalDefinition.input.researchers.status.${researcher.status}`)}
               </Text>
             )}
             {researcher.status == "included" && (
@@ -100,7 +102,7 @@ export default function IncludedResearchers({researchers, setResearchers}:any) {
                   rightIcon={<ChevronDownIcon />}
                   fontWeight="normal"
                 >
-                  Role: {researcher.role}
+                  {`${t("generalDefinition.input.researchers.role.role")}: ${t(`generalDefinition.input.researchers.role.${researcher.role}`)}`}
                 </MenuButton>
                 <MenuList>
                   {AVAILABLE_ROLES.map((role) => (
@@ -109,7 +111,7 @@ export default function IncludedResearchers({researchers, setResearchers}:any) {
                       isDisabled={role === researcher.role}
                       onClick={() => changeRole(researcher.id, role)}
                     >
-                      {role}
+                      {t(`generalDefinition.input.researchers.role.${role}`)}
                     </MenuItem>
                   ))}
                 </MenuList>

--- a/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/index.tsx
+++ b/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/index.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { Text, VStack } from "@chakra-ui/react";
 import AddResearcher from "./AddResearcher";
 import IncludedResearchers from "./IncludedResearchers";
@@ -6,10 +7,11 @@ import { researchersMock } from "../../../../../../../mocks/researchers";
 
 export default function ResearcherFilter() {
   const [researchers, setResearchers] = useState(researchersMock)
+  const { t } = useTranslation("review/planning-protocol"); 
 
   return (
     <>
-      <Text mt={"30px"} fontWeight={500} fontSize={"large"}>Researchers</Text>
+      <Text mt={"30px"} fontWeight={500} fontSize={"large"}>{t("generalDefinition.input.researchers.label")}</Text>
 
       <VStack spacing={0} align="stretch" border="2px solid" borderColor="gray.300" borderRadius="md" bgColor="#ffffffff" px={2} py={2}>
         <AddResearcher researchers={researchers} setResearchers={setResearchers}/>

--- a/src/locales/en/review/planning-protocol.json
+++ b/src/locales/en/review/planning-protocol.json
@@ -20,7 +20,18 @@
             },
             "researchers": {
                 "label": "Researchers",
-                "placeholder": "Enter the name of the researchers "
+                "placeholder": "Add a researcher",
+                "status": {
+                    "pending": "Pending",
+                    "expired": "Expired",
+                    "excluding": "Excluding"               
+                },
+                "role": {
+                    "role": "Role",
+                    "admin": "admin",
+                    "reviewer": "reviewer",
+                    "owner": "owner"
+                }
             }
         },
         "alert": {

--- a/src/locales/en/review/planning-protocol.json
+++ b/src/locales/en/review/planning-protocol.json
@@ -21,6 +21,7 @@
             "researchers": {
                 "label": "Researchers",
                 "placeholder": "Add a researcher",
+                "noResearchersFound": "No researchers found",
                 "status": {
                     "pending": "Pending",
                     "expired": "Expired",

--- a/src/locales/pt/review/planning-protocol.json
+++ b/src/locales/pt/review/planning-protocol.json
@@ -21,6 +21,7 @@
             "researchers": {
                 "label": "Pesquisadores",
                 "placeholder": "Adicione um pesquisador",
+                "noResearchersFound": "Nenhum pesquisador encontrado",
                 "status": {
                     "pending": "Pendente",
                     "expired": "Expirado",

--- a/src/locales/pt/review/planning-protocol.json
+++ b/src/locales/pt/review/planning-protocol.json
@@ -20,7 +20,18 @@
             },
             "researchers": {
                 "label": "Pesquisadores",
-                "placeholder": "Insira o nome dos pesquisadores "
+                "placeholder": "Adicione um pesquisador",
+                "status": {
+                    "pending": "Pendente",
+                    "expired": "Expirado",
+                    "excluding": "Excluído"
+                },
+                "role": {
+                    "role": "Função",
+                    "admin": "administrador",
+                    "reviewer": "revisor",
+                    "owner": "dono"
+                }
             }
         },
         "alert": {


### PR DESCRIPTION
## Summary
This PR adds internationalization support to the researchers component using i18n.

New fields were added to the translation JSON files and integrated into the researchers component.

## Changes
- Add `status` and `role` fields to the `researchers` section of the `review/planning-protocol` translation JSON files
- Apply the new translations throughout the researchers component

## Screenshots

### Portuguese

<img width="1918" height="912" alt="researchers-português" src="https://github.com/user-attachments/assets/6821af7d-7cbb-4339-bd85-2aec4474eeb5" />

### English

<img width="1918" height="912" alt="researchers-inglês" src="https://github.com/user-attachments/assets/a952a23b-231e-4246-ad7d-e673711e31cd" />
