### PR TITLE
GM-feat-researchers-editing-and-deleting-modal

### DIFF
--- a/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/IncludedResearchers.tsx
+++ b/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/IncludedResearchers.tsx
@@ -1,12 +1,32 @@
 import { useTranslation } from "react-i18next";
 import { ChevronDownIcon, EditIcon, DeleteIcon } from "@chakra-ui/icons";
-import { Avatar, Button, Flex, Icon, Menu, MenuButton, MenuItem, MenuList, Text } from "@chakra-ui/react";
-import { useState, useEffect } from "react";
+import { Avatar,
+  Button,
+  Flex,
+  Icon,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Text,
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+} from "@chakra-ui/react";
+import { useState, useEffect, useRef } from "react";
 
 const AVAILABLE_ROLES = ["admin", "reviewer", "owner"] as const;
 
 export default function IncludedResearchers({researchers, setResearchers}:any) {
   const { t } = useTranslation("review/planning-protocol"); 
+
+  const [researcherToDelete, setResearcherToDelete] = useState<any>(null);
+  
+  const cancelRef = useRef<HTMLButtonElement>(null!);
+
   // Backend
   function filterSearch(search: string){
     return function (researcher:any){
@@ -75,14 +95,13 @@ export default function IncludedResearchers({researchers, setResearchers}:any) {
     setEditingRole("");
   }
 
-  const handleDelete = (id: string, name: string, email: string) => {
-    const confirmed = window.confirm(
-      `Are you sure you want to delete ${name} (${email})?`,
-    );
-    if (!confirmed) return;
+  const handleDelete = () => {
+    if (!researcherToDelete) return;
 
-    excludeResearcher(id);
-  };
+    excludeResearcher(researcherToDelete.id);
+
+    setResearcherToDelete(null);
+  }
 
   useEffect(() => {
     setListedResearchers([
@@ -149,7 +168,7 @@ export default function IncludedResearchers({researchers, setResearchers}:any) {
                     <Button
                       variant="ghost"
                       onClick={() =>
-                        handleDelete(researcher.id, researcher.name, researcher.email)
+                        setResearcherToDelete(researcher)
                       }
                     >
                       <Icon as={DeleteIcon} w="15px" h="15px"/>
@@ -177,7 +196,7 @@ export default function IncludedResearchers({researchers, setResearchers}:any) {
                 <Button
                   variant="ghost"
                   onClick={() =>
-                    handleDelete( researcher.id, researcher.name, researcher.email)
+                    setResearcherToDelete(researcher)
                   }
                 >
                   <Icon as={DeleteIcon} w="15px" h="15px"/>
@@ -187,6 +206,44 @@ export default function IncludedResearchers({researchers, setResearchers}:any) {
           </Flex>
         </Flex>
       ))}
+      <AlertDialog
+        isOpen={!!researcherToDelete}
+        leastDestructiveRef={cancelRef}
+        onClose={() => setResearcherToDelete(null)}
+      >
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader color="#2E4B6C" fontSize="lg" fontWeight="bold">
+              Delete researcher
+            </AlertDialogHeader>
+
+            <AlertDialogBody color="#2E4B6C">
+              Are you sure you want to delete{" "}
+              <strong>
+                {researcherToDelete?.name}
+              </strong>
+              ?
+            </AlertDialogBody>
+
+            <AlertDialogFooter>
+              <Button
+                ref={cancelRef}
+                onClick={() => setResearcherToDelete(null)}
+              >
+                Cancel
+              </Button>
+
+              <Button
+                colorScheme="red"
+                onClick={handleDelete}
+                ml={3}
+              >
+                Delete
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
     </>
   );
 }

--- a/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/IncludedResearchers.tsx
+++ b/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/IncludedResearchers.tsx
@@ -214,11 +214,11 @@ export default function IncludedResearchers({researchers, setResearchers}:any) {
         <AlertDialogOverlay>
           <AlertDialogContent>
             <AlertDialogHeader color="#2E4B6C" fontSize="lg" fontWeight="bold">
-              Delete researcher
+              {t("generalDefinition.input.researchers.confirm.title")}
             </AlertDialogHeader>
 
             <AlertDialogBody color="#2E4B6C">
-              Are you sure you want to delete{" "}
+              {`${t("generalDefinition.input.researchers.confirm.body")} `}
               <strong>
                 {researcherToDelete?.name}
               </strong>
@@ -230,7 +230,7 @@ export default function IncludedResearchers({researchers, setResearchers}:any) {
                 ref={cancelRef}
                 onClick={() => setResearcherToDelete(null)}
               >
-                Cancel
+                {t("generalDefinition.input.researchers.confirm.cancel")}
               </Button>
 
               <Button
@@ -238,7 +238,7 @@ export default function IncludedResearchers({researchers, setResearchers}:any) {
                 onClick={handleDelete}
                 ml={3}
               >
-                Delete
+                {t("generalDefinition.input.researchers.confirm.delete")}
               </Button>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/IncludedResearchers.tsx
+++ b/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/IncludedResearchers.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { ChevronDownIcon, DeleteIcon } from "@chakra-ui/icons";
+import { ChevronDownIcon, EditIcon, DeleteIcon } from "@chakra-ui/icons";
 import { Avatar, Button, Flex, Icon, Menu, MenuButton, MenuItem, MenuList, Text } from "@chakra-ui/react";
 import { useState, useEffect } from "react";
 
@@ -63,6 +63,18 @@ export default function IncludedResearchers({researchers, setResearchers}:any) {
     ...filterSearchAndStatus({ status: "included" }),
   ]);
 
+  const [editingResearcherId, setEditingResearcherId] = useState<string | null>(null);
+  const [editingRole, setEditingRole] = useState("");
+
+  function handleSaveRole() {
+    if (!editingResearcherId || !editingRole) return;
+
+    changeRole(editingResearcherId, editingRole);
+
+    setEditingResearcherId(null);
+    setEditingRole("");
+  }
+
   const handleDelete = (id: string, name: string, email: string) => {
     const confirmed = window.confirm(
       `Are you sure you want to delete ${name} (${email})?`,
@@ -82,53 +94,99 @@ export default function IncludedResearchers({researchers, setResearchers}:any) {
 
   return (
     <>
-    {listedResearchers.map((researcher:any) => (
-      <Flex align="center" gap={5} px ={4} py={2} borderWidth="1px" borderColor="gray.200" borderRadius="md">
-        <Avatar size="sm" name={researcher.name} bg="#2E4B6C" color="white" />
-        <Flex align="center" justify="space-between" flex="1">
-          <Text>{researcher.name} - {researcher.email}</Text>
-          <Flex align="center" gap={5}>
-            {(researcher.status === "pending" || researcher.status === "expired" || researcher.status === "excluding") && (
-              <Text color="gray.500">
-                {t(`generalDefinition.input.researchers.status.${researcher.status}`)}
-              </Text>
-            )}
-            {researcher.status == "included" && (
-              <Menu>
-                <MenuButton
-                  as={Button}
-                  variant="ghost"
-                  size="sm"
-                  rightIcon={<ChevronDownIcon />}
-                  fontWeight="normal"
-                >
-                  {`${t("generalDefinition.input.researchers.role.role")}: ${t(`generalDefinition.input.researchers.role.${researcher.role}`)}`}
-                </MenuButton>
-                <MenuList>
-                  {AVAILABLE_ROLES.map((role) => (
-                    <MenuItem
-                      key={role}
-                      isDisabled={role === researcher.role}
-                      onClick={() => changeRole(researcher.id, role)}
+      {listedResearchers.map((researcher:any) => (
+        <Flex key={researcher.id} align="center" gap={5} px={4} py={2} borderWidth="1px" borderColor="gray.200" borderRadius="md">
+          <Avatar size="sm" name={researcher.name} bg="#2E4B6C" color="white"/>
+          <Flex align="center" justify="space-between" flex="1">
+            <Text>{researcher.name} - {researcher.email}</Text>
+            <Flex alignItems="center" justifyContent="center" gap={5}>
+              {(researcher.status === "pending" || researcher.status === "expired" || researcher.status === "excluding") && (
+                <Text color="gray.500">
+                  {t(`generalDefinition.input.researchers.status.${researcher.status}`)}
+                </Text>
+              )}
+              {researcher.status === "included" ? (
+                <>
+                  {editingResearcherId === researcher.id ? (
+                    <Menu>
+                      <MenuButton
+                        as={Button}
+                        variant="ghost"
+                        size="sm"
+                        rightIcon={<ChevronDownIcon w={18} h={18}/>}
+                        fontWeight="normal"
+                        fontSize={16}
+                        h="100%"
+                        w="200px"
+                        p="0"
+                        textAlign="start"
+                        display="flex"
+                        alignItems="center"
+                        justifyContent="center"
+                        lineHeight="40px"
+                        borderInline="3px solid transparent"
+                        outline="1px solid black"
+                      >
+                        {`${t("generalDefinition.input.researchers.role.role")}: ${t(`generalDefinition.input.researchers.role.${editingRole}`)}`}
+                      </MenuButton>
+                      <MenuList>
+                        {AVAILABLE_ROLES.map((role) => (
+                          <MenuItem
+                            key={role}
+                            onClick={() => setEditingRole(role)}
+                          >
+                            {t(`generalDefinition.input.researchers.role.${role}`)}
+                          </MenuItem>
+                        ))}
+                      </MenuList>
+                    </Menu>
+                  ) : (
+                    <Text w="200px" h="100%" borderInline="3px solid transparent" p={0} display="flex" alignItems="center" lineHeight="20px">
+                      {`${t("generalDefinition.input.researchers.role.role")}: ${t(`generalDefinition.input.researchers.role.${researcher.role}`)}`}
+                    </Text>
+                  )}
+                  <Flex>
+                    <Button
+                      variant="ghost"
+                      onClick={() =>
+                        handleDelete(researcher.id, researcher.name, researcher.email)
+                      }
                     >
-                      {t(`generalDefinition.input.researchers.role.${role}`)}
-                    </MenuItem>
-                  ))}
-                </MenuList>
-              </Menu>
-            )}
-            <Button
-              variant="ghost"
-              onClick={() =>
-                handleDelete(researcher.id, researcher.name, researcher.email)
-              }
-            >
-              <Icon as={DeleteIcon} w={"15px"} h={"15px"} />
-            </Button>
-          </Flex> 
+                      <Icon as={DeleteIcon} w="15px" h="15px"/>
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      onClick={() => {
+                        if(editingResearcherId === researcher.id) {
+                          handleSaveRole();
+                        } else {
+                          setEditingResearcherId(researcher.id);
+                          setEditingRole(researcher.role);
+                        }
+                      }}
+                    >
+                      {editingResearcherId === researcher.id ? (
+                        <i className="pi pi-save" style={{ color: "black", width: "15px", height: "15px" }}></i>
+                      ) : (
+                        <Icon as={EditIcon} w="15px" h="15px"/>
+                      )}
+                    </Button>
+                  </Flex>
+                </>
+              ) : (
+                <Button
+                  variant="ghost"
+                  onClick={() =>
+                    handleDelete( researcher.id, researcher.name, researcher.email)
+                  }
+                >
+                  <Icon as={DeleteIcon} w="15px" h="15px"/>
+                </Button>
+              )}
+            </Flex>
+          </Flex>
         </Flex>
-      </Flex>
-    ))}
+      ))}
     </>
   );
 }

--- a/src/locales/en/review/planning-protocol.json
+++ b/src/locales/en/review/planning-protocol.json
@@ -32,6 +32,12 @@
                     "admin": "admin",
                     "reviewer": "reviewer",
                     "owner": "owner"
+                },
+                "confirm": {
+                    "title": "Delete researcher",
+                    "body": "Are you sure you want to delete",
+                    "cancel": "Cancel",
+                    "delete": "Delete"
                 }
             }
         },

--- a/src/locales/pt/review/planning-protocol.json
+++ b/src/locales/pt/review/planning-protocol.json
@@ -32,6 +32,12 @@
                     "admin": "administrador",
                     "reviewer": "revisor",
                     "owner": "dono"
+                },
+                "confirm": {
+                    "title": "Remover pesquisador",
+                    "body": "Tem certeza que quer remover",
+                    "cancel": "Cancelar",
+                    "delete": "Remover"
                 }
             }
         },


### PR DESCRIPTION
# Summary
This PR changes the researcher role editing flow by replacing the always-visible dropdown menu with an edit icon.
It also replaces the native `confirm()` dialog with an internationalized modal to confirm researcher deletion.

# Changes

## Editing a researcher's role
Replaces the dropdown menu that was always enabled with an edit icon.  
When clicked, the edit icon enables the dropdown and changes into a save icon.  
After selecting a new role, the user can click the save icon to persist the change.

## Researcher deletion modal
Replaces the native `confirm()` dialog with a modal to confirm researcher deletion.  
Also adds internationalization using `i18n` for the new confirmation modal.

# Screenshots

## Editing

### New edit icon

<img width="1918" height="913" alt="edicao" src="https://github.com/user-attachments/assets/7ec93127-e88a-41a9-8ed3-9d74d215743b" />

### Enabled dropdown

<img width="1918" height="912" alt="edicao-habilitada" src="https://github.com/user-attachments/assets/9e0f3752-33c8-455b-b7f2-d7ab271f202a" />

### Opened dropdown

<img width="1918" height="912" alt="menu-aberto" src="https://github.com/user-attachments/assets/5228b8df-b8f3-4189-ae97-7f9718fa6ac3" />

---

## Deletion modal

<img width="1918" height="913" alt="modal-delecao" src="https://github.com/user-attachments/assets/f105888d-340b-43d8-8cc0-fca335da6fd5" />