### PR TITLE
fix:Adjusted container height and flex properties on Selection and Ex…

### DIFF
--- a/src/features/review/execution-extraction/pages/Extraction/index.tsx
+++ b/src/features/review/execution-extraction/pages/Extraction/index.tsx
@@ -101,7 +101,7 @@ export default function Extraction() {
 
   return (
     <FlexLayout navigationType="Accordion">
-      <Box w="100%" px="1rem" py=".75rem" h="fit-content">
+      <Box w="100%" px="1rem" pt="0" pb=".75rem" h="fit-content">
         <Flex
           w="100%"
           h="2.5rem"
@@ -153,8 +153,27 @@ export default function Extraction() {
       </Box>
       <Box
         w="calc(100% - 1.25rem)"
-        h="calc(100vh - 10rem)"
+        h="calc(100vh - 9.5rem - 20px)" 
         padding="0 0 0 .5rem"
+        position="relative"
+        top="30px" 
+        display="flex"
+        flexDirection="column"
+        sx={{
+          "& > div": {
+            flex: 1, 
+            display: "flex",
+            flexDirection: "column",
+            minHeight: 0,
+            marginBottom: "0px !important", 
+            paddingBottom: "0px !important"
+          },
+          "& > div > div": {
+            flex: 1,
+            overflowY: "auto",
+            marginBottom: "0px !important"
+          }
+        }}
       >
         <LayoutFactory
           page="Extraction"

--- a/src/features/review/execution-selection/pages/Selection/index.tsx
+++ b/src/features/review/execution-selection/pages/Selection/index.tsx
@@ -105,7 +105,7 @@ export default function Selection() {
 
   return (
     <FlexLayout navigationType="Accordion">
-      <Box w="100%" px="1rem" py=".75rem" h="fit-content">
+      <Box w="100%" px="1rem" pt="0" pb=".75rem" h="fit-content">
         <Flex
           w="100%"
           h="2.5rem"
@@ -156,8 +156,27 @@ export default function Selection() {
       </Box>
       <Box
         w="calc(100% - 1.25rem)"
-        h="calc(100vh - 10rem)"
+        h="calc(100vh - 9.5rem - 20px)" 
         padding="0 0 0 .5rem"
+        position="relative"
+        top="30px" 
+        display="flex"
+        flexDirection="column"
+        sx={{
+          "& > div": {
+            flex: 1, 
+            display: "flex",
+            flexDirection: "column",
+            minHeight: 0,
+            marginBottom: "0px !important", 
+            paddingBottom: "0px !important"
+          },
+          "& > div > div": {
+            flex: 1,
+            overflowY: "auto",
+            marginBottom: "0px !important"
+          }
+        }}
       >
         <LayoutFactory
           page="Selection"


### PR DESCRIPTION
## fix

Adjusted the layout properties (height, flex positioning, and margins) of the main containers on the **Extraction** and **Selection** pages

- Fixed the alignment so the bottom of the table cards is leveled with the bottom of the sidebar.