### PR TITLE
feat(graphics): add pick-many conditional rendering with bar, bubble, item table and aggregated table views

### DIFF
--- a/src/features/review/summarization-graphics/components/export/ExportCsv/CsvQuestions/buildQuestionsCsv.tsx
+++ b/src/features/review/summarization-graphics/components/export/ExportCsv/CsvQuestions/buildQuestionsCsv.tsx
@@ -8,6 +8,7 @@ type ExtractionAnswer = {
     code: string;
     description: string;
     questionType: string;
+    options?: string[] | null;
   };
   answer: Record<string, number[]>;
 };
@@ -20,11 +21,127 @@ function csvEscape(value: string | number) {
   return str;
 }
 
+function parsePickManyLabel(label: string): string[] {
+  const trimmed = label.trim();
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    return trimmed
+      .slice(1, -1)
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return [trimmed];
+}
+
+function buildAggregatedCsv(
+  q: ExtractionAnswer,
+  filteredStudyIds: Set<number>
+): CsvRow[] {
+  const { question, answer } = q;
+
+  let totalResponses: number;
+
+  if (question.questionType === "PICK_MANY") {
+    const counts = new Map<string, Set<number>>();
+    Object.entries(answer ?? {}).forEach(([label, ids]) => {
+      const validIds = (Array.isArray(ids) ? ids : [])
+        .map(Number)
+        .filter((id) => filteredStudyIds.has(id));
+      const options = parsePickManyLabel(label);
+      options.forEach((opt) => {
+        if (!counts.has(opt)) counts.set(opt, new Set());
+        validIds.forEach((id) => counts.get(opt)!.add(id));
+      });
+    });
+
+    totalResponses = [...counts.values()].reduce(
+      (sum, set) => sum + set.size,
+      0
+    );
+
+    return [...counts.entries()]
+      .filter(([, ids]) => ids.size > 0)
+      .map(([option, ids]) => ({
+        questionCode: question.code,
+        question: csvEscape(question.description),
+        option: csvEscape(option),
+        studies: csvEscape([...ids].join(", ")),
+        count: ids.size,
+        percentage: `${((ids.size / totalResponses) * 100).toFixed(2)}%`,
+      }));
+  }
+
+  totalResponses = Object.values(answer ?? {}).reduce(
+    (sum, ids) =>
+      sum +
+      (Array.isArray(ids)
+        ? ids.filter((id) => filteredStudyIds.has(Number(id))).length
+        : 0),
+    0
+  );
+
+  const rows: CsvRow[] = [];
+
+  Object.entries(answer ?? {}).forEach(([label, ids]) => {
+    const validIds = (Array.isArray(ids) ? ids : [])
+      .map(Number)
+      .filter((id) => filteredStudyIds.has(id));
+
+    if (validIds.length === 0) return;
+
+    rows.push({
+      questionCode: question.code,
+      question: csvEscape(question.description),
+      option: csvEscape(label),
+      studies: csvEscape(validIds.join(", ")),
+      count: validIds.length,
+      percentage: `${((validIds.length / totalResponses) * 100).toFixed(2)}%`,
+    });
+  });
+
+  return rows;
+}
+
+function buildPickManyItemCsv(
+  q: ExtractionAnswer,
+  filteredStudyIds: Set<number>
+): CsvRow[] {
+  const { question, answer } = q;
+  const options = question.options ?? [];
+
+  const selectionMap = new Map<number, Set<string>>();
+
+  Object.entries(answer ?? {}).forEach(([label, ids]) => {
+    const selected = parsePickManyLabel(label);
+    (Array.isArray(ids) ? ids : [])
+      .map(Number)
+      .filter((id) => filteredStudyIds.has(id))
+      .forEach((id) => {
+        if (!selectionMap.has(id)) selectionMap.set(id, new Set());
+        selected.forEach((opt) => selectionMap.get(id)!.add(opt));
+      });
+  });
+
+  return [...selectionMap.entries()].map(([studyId, selected]) => {
+    const row: CsvRow = {
+      questionCode: question.code,
+      question: csvEscape(question.description),
+      studyId,
+    };
+
+    options.forEach((opt) => {
+      row[csvEscape(opt)] = selected.has(opt) ? "Yes" : "No";
+    });
+
+    return row;
+  });
+}
 
 export function buildQuestionsCsv(
   extractionAnswers: ExtractionAnswer[],
   filteredStudies: ArticleInterface[],
-  selectedQuestionId?: string
+  selectedQuestionId?: string,
+  type?: string
 ): CsvRow[] {
   const filteredStudyIds = new Set(
     filteredStudies.map((s) => Number(s.studyReviewId))
@@ -35,42 +152,19 @@ export function buildQuestionsCsv(
         (q) => q.question.questionId === selectedQuestionId
       )
     : extractionAnswers.length
-      ? [extractionAnswers[0]]
-      : [];
+    ? [extractionAnswers[0]]
+    : [];
 
   if (answers.length === 0) return [];
 
   const rows: CsvRow[] = [];
 
   answers.forEach((q) => {
-    const { question, answer } = q;
-
-    // total de respostas - percentual
-    const totalResponses = Object.values(answer ?? {}).reduce(
-      (sum, ids) =>
-        sum +
-        (Array.isArray(ids)
-          ? ids.filter((id) => filteredStudyIds.has(Number(id))).length
-          : 0),
-      0
-    );
-
-    Object.entries(answer ?? {}).forEach(([label, ids]) => {
-      const validIds = (Array.isArray(ids) ? ids : [])
-        .map(Number)
-        .filter((id) => filteredStudyIds.has(id));
-
-      if (validIds.length === 0) return;
-
-      rows.push({
-        questionCode: question.code,
-        question: csvEscape(question.description),
-        option: csvEscape(label),
-        studies: csvEscape(validIds.join(", ")), 
-        count: validIds.length,
-        percentage: `${((validIds.length / totalResponses) * 100).toFixed(2)}%`,
-      });
-    });
+    if (q.question.questionType === "PICK_MANY" && type === "Item Table") {
+      rows.push(...buildPickManyItemCsv(q, filteredStudyIds));
+    } else {
+      rows.push(...buildAggregatedCsv(q, filteredStudyIds));
+    }
   });
 
   return rows;

--- a/src/features/review/summarization-graphics/components/tables/PickManyItemTable/index.tsx
+++ b/src/features/review/summarization-graphics/components/tables/PickManyItemTable/index.tsx
@@ -1,0 +1,178 @@
+import {Box,Table,TableContainer,Tbody,Td,Text,Th,Thead,Tooltip,Tr} from "@chakra-ui/react";
+import { useMemo } from "react";
+
+import PaginationControl from "@features/review/shared/components/common/tables/ArticlesTable/subcomponents/controlls/PaginationControl";
+import { useExport } from "@features/review/summarization-graphics/context/ExportContext";
+import useGenericPagination from "@features/review/summarization-graphics/hooks/useGenericPaginations";
+
+interface PickManyItemRow {
+  studyId: number;
+  selections: Record<string, boolean>;
+}
+
+interface Props {
+  data: Record<string, number[]>;
+  options: string[];
+  studyIds: number[];
+}
+
+function parsePickManyLabel(label: string): string[] {
+  const trimmed = label.trim();
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    return trimmed
+      .slice(1, -1)
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return [trimmed];
+}
+
+function buildSelectionMap(
+  data: Record<string, number[]>
+): Map<number, Set<string>> {
+  const map = new Map<number, Set<string>>();
+
+  Object.entries(data).forEach(([label, ids]) => {
+    const selected = parsePickManyLabel(label);
+    ids.forEach((id) => {
+      if (!map.has(id)) map.set(id, new Set());
+      selected.forEach((opt) => map.get(id)!.add(opt));
+    });
+  });
+
+  return map;
+}
+
+export function PickManyItemTable({ data, options, studyIds }: Props) {
+  const { isExporting } = useExport();
+
+  const selectionMap = useMemo(() => buildSelectionMap(data), [data]);
+
+  const rows: PickManyItemRow[] = useMemo(() => {
+    return studyIds
+      .filter((id) => selectionMap.has(id))
+      .map((id) => ({
+        studyId: id,
+        selections: Object.fromEntries(
+          options.map((opt) => [opt, selectionMap.get(id)?.has(opt) ?? false])
+        ),
+      }));
+  }, [studyIds, selectionMap, options]);
+
+  const {
+    currentPage,
+    itensPerPage,
+    quantityOfPages,
+    paginatedItems,
+    handleNextPage,
+    handlePrevPage,
+    handleBackToInitial,
+    handleGoToFinal,
+    changeQuantityOfItens,
+  } = useGenericPagination<PickManyItemRow>(rows);
+
+  return (
+    <Box w="100%">
+      <TableContainer
+        w="100%"
+        maxH={isExporting ? "none" : "calc(100vh - 35rem)"}
+        overflowY={isExporting ? "visible" : "auto"}
+        overflowX="auto"
+        borderRadius="1rem 1rem 0 0"
+        boxShadow="lg"
+        bg="white"
+      >
+        <Table variant="unstyled" size="md">
+          <Thead
+            position={isExporting ? "static" : "sticky"}
+            top={0}
+            zIndex={1}
+            bg="white"
+            borderBottom=".5rem solid #C9D9E5"
+          >
+            <Tr>
+              <Th
+                fontSize="medium"
+                color="#263C56"
+                textTransform="none"
+                px={4}
+                minW="56px"
+              >
+                ID
+              </Th>
+
+              {options.map((opt) => (
+                <Th
+                  key={opt}
+                  fontSize="medium"
+                  color="#263C56"
+                  textTransform="none"
+                  px={4}
+                  minW="80px"
+                  textAlign="center"
+                >
+                  {isExporting ? (
+                    <Text wordBreak="break-word" px={2}>
+                      {opt}
+                    </Text>
+                  ) : (
+                    <Tooltip label={opt} hasArrow>
+                      <Text isTruncated maxW="120px">
+                        {opt}
+                      </Text>
+                    </Tooltip>
+                  )}
+                </Th>
+              ))}
+            </Tr>
+          </Thead>
+
+          <Tbody>
+            {paginatedItems.length > 0 ? (
+              paginatedItems.map((row) => (
+                <Tr key={row.studyId}>
+                  <Td px={4} verticalAlign="top">
+                    <Text>{row.studyId}</Text>
+                  </Td>
+
+                  {options.map((opt) => (
+                    <Td
+                      key={opt}
+                      textAlign="center"
+                      verticalAlign="top"
+                      px={4}
+                      color={row.selections[opt] ? "green.500" : "red.400"}
+                      fontWeight="semibold"
+                    >
+                      {row.selections[opt] ? "✓" : "✗"}
+                    </Td>
+                  ))}
+                </Tr>
+              ))
+            ) : (
+              <Tr>
+                <Td colSpan={options.length + 1} textAlign="center">
+                  No data found.
+                </Td>
+              </Tr>
+            )}
+          </Tbody>
+        </Table>
+      </TableContainer>
+
+      {!isExporting && (
+        <PaginationControl
+          currentPage={currentPage}
+          itensPerPage={itensPerPage}
+          quantityOfPages={quantityOfPages}
+          handleNextPage={handleNextPage}
+          handlePrevPage={handlePrevPage}
+          handleBackToInitial={handleBackToInitial}
+          handleGoToFinal={handleGoToFinal}
+          changeQuantityOfItens={changeQuantityOfItens}
+        />
+      )}
+    </Box>
+  );
+}

--- a/src/features/review/summarization-graphics/hooks/useGraphicsState.tsx
+++ b/src/features/review/summarization-graphics/hooks/useGraphicsState.tsx
@@ -40,6 +40,8 @@ export function useGraphicsState() {
       case "PICK_LIST":
         return [
           t("selectMenu.graphicsTypes.pieChart"),
+          t("selectMenu.graphicsTypes.barChart"),
+          t("selectMenu.graphicsTypes.bubbleChart"),
           t("selectMenu.graphicsTypes.table"),
         ];
       case "PICK_MANY":

--- a/src/features/review/summarization-graphics/hooks/useGraphicsState.tsx
+++ b/src/features/review/summarization-graphics/hooks/useGraphicsState.tsx
@@ -14,12 +14,12 @@ export type FiltersState = {
 
 export function useGraphicsState() {
   const { t } = useTranslation("review/summarization-graphics");
-  // perguntas
+
   const { questions: extractionQuestions = [] } = useFetchExtractionQuestions();
   const { questions: robQuestions = [] } = useFetchRobQuestions();
   const allQuestions = useMemo(
     () => [...extractionQuestions, ...robQuestions],
-    [extractionQuestions, robQuestions],
+    [extractionQuestions, robQuestions]
   );
 
   const [selectedQuestionId, setSelectedQuestionId] = useState<
@@ -40,13 +40,13 @@ export function useGraphicsState() {
       case "PICK_LIST":
         return [
           t("selectMenu.graphicsTypes.pieChart"),
-          t("selectMenu.graphicsTypes.barChart"),
-          t("selectMenu.graphicsTypes.bubbleChart"),
           t("selectMenu.graphicsTypes.table"),
         ];
       case "PICK_MANY":
         return [
           t("selectMenu.graphicsTypes.barChart"),
+          t("selectMenu.graphicsTypes.bubbleChart"),
+          t("selectMenu.graphicsTypes.itemTable"),
           t("selectMenu.graphicsTypes.table"),
         ];
       default:
@@ -54,7 +54,6 @@ export function useGraphicsState() {
     }
   };
 
-  // tipos por seção
   const allowedTypes: Record<string, string[]> = {
     "Search Sources": [
       t("selectMenu.graphicsTypes.pieChart"),

--- a/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/FormQuestionsRenderer/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/FormQuestionsRenderer/index.tsx
@@ -12,7 +12,7 @@ type Props = {
   chartId: string;
   selectedQuestionId?: string;
   columnsVisible: ColumnVisibility;
-  setTablePage: Dispatch<SetStateAction<PageLayout>>
+  setTablePage: Dispatch<SetStateAction<PageLayout>>;
 };
 
 export default function FormQuestionsRenderer({
@@ -21,16 +21,10 @@ export default function FormQuestionsRenderer({
   selectedQuestionId,
   chartId,
   columnsVisible,
-  setTablePage
+  setTablePage,
 }: Props) {
   return (
-    <Box 
-      id={chartId}
-      w="100%"
-      display="block" 
-      pt={4} 
-      pb={10}
-    >
+    <Box id={chartId}>
       <QuestionsCharts
         filteredStudies={filteredStudies as ArticleInterface[]}
         type={type}

--- a/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/index.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { Box, Flex } from "@chakra-ui/react";
 import { graphicsconteiner } from "../../styles";
 
@@ -10,6 +10,7 @@ import SearchSourcesRenderer from "./SearchSourcesRenderer";
 import IncludedStudiesRenderer from "./IncludedStudiesRenderer";
 import CriteriaRenderer from "./CriteriaRenderer";
 import StudiesFunnelRenderer from "./StudiesFunnelRenderer";
+import ProtocolRenderer from "./ProtocolRenderer";
 import DownloadChartsButton from "@features/review/summarization-graphics/components/buttons/DownloadChatsButton";
 import FormQuestionsRenderer from "./FormQuestionsRenderer";
 import { downloadCSV } from "@features/review/summarization-graphics/components/export/ExportCsv";
@@ -21,6 +22,7 @@ import { useFetchStudiesByStage } from "@features/review/summarization-graphics/
 import useFetchStudiesByCriteria from "@features/review/summarization-graphics/services/useFetchStudiesByCriteria";
 import { ColumnVisibility } from "@features/review/shared/hooks/useVisibilityColumns";
 import { PageLayout } from "@features/review/shared/components/structure/LayoutFactory";
+import { Dispatch, SetStateAction } from "react";
 
 type Props = {
   section: string;
@@ -28,7 +30,7 @@ type Props = {
   filters: FiltersState;
   selectedQuestionId?: string;
   columnsVisible: ColumnVisibility;
-  setTablePage: Dispatch<SetStateAction<PageLayout>>
+  setTablePage: Dispatch<SetStateAction<PageLayout>>;
 };
 export type CsvRow = Record<string, string | number>;
 
@@ -38,16 +40,13 @@ export default function ChartsRenderer({
   filters,
   selectedQuestionId,
   columnsVisible,
-  setTablePage
+  setTablePage,
 }: Props) {
   const { articles, isLoading } = useGetAllReviewArticles();
-  const [, setCsvData] = useState<CsvRow[]>([]);
 
   const { extractionAnswers } = useFetchQuestionAnswers();
 
-  const handleCsvData = useCallback((data: CsvRow[]) => {
-    setCsvData(data);
-  }, []);
+  const handleCsvData = useCallback((_data: CsvRow[]) => {}, []);
 
   const filteredStudies = useMemo(() => {
     return articles
@@ -106,13 +105,12 @@ export default function ChartsRenderer({
 
   const chartId = `chart-${section.replace(/\s+/g, "-").toLowerCase()}`;
 
-  // Map de renderers
   const rendererMap: Record<string, any> = {
     "Search Sources": (props: any) => (
-      <SearchSourcesRenderer {...props} columnsVisible={columnsVisible} chartId={chartId} />
+      <SearchSourcesRenderer {...props} chartId={chartId} />
     ),
     "Included Studies": (props: any) => (
-      <IncludedStudiesRenderer {...props} columnsVisible={columnsVisible} chartId={chartId} />
+      <IncludedStudiesRenderer {...props} chartId={chartId} />
     ),
     "S1_Inclusion Criteria": (props: any) => (
       <CriteriaRenderer
@@ -156,72 +154,63 @@ export default function ChartsRenderer({
       />
     ),
     "Studies Funnel": () => <StudiesFunnelRenderer chartId={chartId} />,
+    Protocol: () => <ProtocolRenderer />,
   };
 
   const Renderer = rendererMap[section];
   if (!Renderer) return <Box>Seção não encontrada</Box>;
 
-return (
-  <Box
-    sx={{
-      ...graphicsconteiner,
-      minHeight: "calc(100vh - 210px)",
-      justifyContent: "space-between",
-    }}
-  >
+  return (
     <Box
-      display="flex"
-      flexWrap="wrap"
-      gap="2em"
-      justifyContent="center"
-      alignItems="center"
-      p={
-        section === "Included Studies" ||
-        (section === "Search Sources" && (type === "Table" || type === "Tabela"))
-          ? "0"
-          : "2rem"
-      }
-      pt="1rem"
+      pt={"1rem"}
+      sx={{
+        ...graphicsconteiner,
+        p:
+          section === "Included Studies" ||
+          (section === "Search Sources" && type === "Table")
+            ? undefined
+            : "2rem",
+        boxShadow: "md",
+      }}
     >
       <Renderer
         filteredStudies={filteredStudies}
         type={type}
         onCsvData={handleCsvData}
       />
-    </Box>
 
-    {section !== "Studies Funnel" && (
-      <Flex w="100%" justifyContent="flex-end" p="1rem">
-        <DownloadChartsButton
-          selector={`#${chartId}`}
-          fileName={section}
-          onDownloadCsv={() => {
-            if (section === "Form Questions") 
-              {
-              downloadCSV(
-                "questions",
-                buildQuestionsCsv(
-                  extractionAnswers,
-                  filteredStudies as ArticleInterface[],
-                  selectedQuestionId
-                )
-              );
-            } else {
-              downloadCSV(
-                section,
-                getCsvData(
+      {section !== "Studies Funnel" && section !== "Protocol" && (
+        <Flex w="100%" justifyContent="flex-end" p="1rem">
+          <DownloadChartsButton
+            selector={`#${chartId}`}
+            fileName={section}
+            onDownloadCsv={() => {
+              if (section === "Form Questions") {
+                downloadCSV(
+                  "questions",
+                  buildQuestionsCsv(
+                    extractionAnswers,
+                    filteredStudies as ArticleInterface[],
+                    selectedQuestionId,
+                    type
+                  )
+                );
+              } else {
+                downloadCSV(
                   section,
-                  filteredStudies,
-                  type,
-                  filteredStageIds,
-                  studiesByCriteria
-                )
-              );
-            }
-          }}
-        />
-      </Flex>
-    )}
-  </Box>
-);
+                  getCsvData(
+                    section,
+                    filteredStudies,
+                    type,
+                    filteredStageIds,
+                    studiesByCriteria
+                  )
+                );
+              }
+            }}
+          />
+        </Flex>
+      )}
+    </Box>
+  );
 }

--- a/src/features/review/summarization-graphics/pages/Graphics/subcomponents/QuestionsCharts/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/subcomponents/QuestionsCharts/index.tsx
@@ -8,6 +8,7 @@ import { ColumnVisibility } from "@features/review/shared/hooks/useVisibilityCol
 import useBubbleDataGeneric, { BubbleItem } from "@features/review/summarization-graphics/hooks/useBubbleDataGeneric";
 import BubbleChart from "@features/review/summarization-graphics/components/charts/BubbleChart";
 import TextualTable from "@features/review/summarization-graphics/components/tables/TextualTable";
+import { PickManyItemTable } from "@features/review/summarization-graphics/components/tables/PickManyItemTable";
 import { Dispatch, SetStateAction } from "react";
 import { PageLayout } from "@features/review/shared/components/structure/LayoutFactory";
 
@@ -16,7 +17,7 @@ type Props = {
   filteredStudies: ArticleInterface[];
   type: string;
   columnsVisible: ColumnVisibility;
-  setTablePage: Dispatch<SetStateAction<PageLayout>>
+  setTablePage: Dispatch<SetStateAction<PageLayout>>;
 };
 
 type Question = {
@@ -86,12 +87,43 @@ function updateLabel(question: Question) {
   }
 }
 
+function buildPickManyBubbleItems(
+  filteredEntries: [string, number[]][],
+  filteredStudies: ArticleInterface[]
+): BubbleItem[] {
+  const yearAnswerMap = new Map<string, number>();
+
+  filteredEntries.forEach(([label, ids]) => {
+    const clean = label.replace(/[\[\]]/g, "");
+    const options = clean.split(",").map((s) => s.trim()).filter(Boolean);
+
+    ids.forEach((id) => {
+      const study = filteredStudies.find((s) => s.studyReviewId === id);
+      if (!study) return;
+
+      const year = Number(study.year);
+
+      options.forEach((opt) => {
+        const key = `${year}-${opt}`;
+        yearAnswerMap.set(key, (yearAnswerMap.get(key) || 0) + 1);
+      });
+    });
+  });
+
+  return Array.from(yearAnswerMap.entries()).map(([key, count]) => {
+    const dashIndex = key.indexOf("-");
+    const year = Number(key.slice(0, dashIndex));
+    const answer = key.slice(dashIndex + 1);
+    return { x: year, group: answer, y: count };
+  });
+}
+
 export const QuestionsCharts = ({
   selectedQuestionId,
   filteredStudies,
   type,
   columnsVisible,
-  setTablePage
+  setTablePage,
 }: Props) => {
   const { extractionAnswers, isLoadingExtractionAnswers } =
     useFetchQuestionAnswers();
@@ -125,7 +157,7 @@ export const QuestionsCharts = ({
           ([label, ids]) => {
             const idsArray = Array.isArray(ids) ? ids : [];
             const filteredIds = idsArray
-              .map((id) => Number(id)) 
+              .map((id) => Number(id))
               .filter((id) => filteredStudyIds.has(id));
             return [label, filteredIds] as [string, number[]];
           }
@@ -140,52 +172,41 @@ export const QuestionsCharts = ({
         let chartContent = null;
 
         if (type === "Pie Chart" || type === "Gráfico de Pizza") {
-          chartContent = (
-            <PieChart title="" labels={labels} data={data} />
-          );
+          chartContent = <PieChart title="" labels={labels} data={data} />;
+
         } else if (type === "Bar Chart" || type === "Gráfico de Barras") {
           chartContent = (
-            <BarChart
-              title=""
-              labels={labels}
-              data={data}
-              section="questions"
-            />
+            <BarChart title="" labels={labels} data={data} section="questions" />
           );
+
         } else if (type === "Bubble Chart" || type === "Gráfico de Bolhas") {
-          const yearAnswerMap = new Map<string, number>();
 
-          filteredEntries.forEach(([answer, ids]) => {
-            ids.forEach((id) => {
-              const study = filteredStudies.find(
-                (s) => s.studyReviewId === id
-              );
+          let items: BubbleItem[];
 
-              if (!study) return;
+          if (question.questionType === "PICK_MANY") {
+            items = buildPickManyBubbleItems(filteredEntries, filteredStudies);
+          } else {
+            const yearAnswerMap = new Map<string, number>();
 
-              const year = Number(study.year);
+            filteredEntries.forEach(([answer, ids]) => {
+              ids.forEach((id) => {
+                const study = filteredStudies.find(
+                  (s) => s.studyReviewId === id
+                );
+                if (!study) return;
 
-              const key = `${year}-${answer}`;
-
-              yearAnswerMap.set(
-                key,
-                (yearAnswerMap.get(key) || 0) + 1
-              );
+                const year = Number(study.year);
+                const key = `${year}-${answer}`;
+                yearAnswerMap.set(key, (yearAnswerMap.get(key) || 0) + 1);
+              });
             });
-          });
 
-          const items: BubbleItem[] = Array.from(
-            yearAnswerMap.entries()
-          ).map(([key, count]) => {
-            const [year, answer] = key.split("-");
+            items = Array.from(yearAnswerMap.entries()).map(([key, count]) => {
+              const [year, answer] = key.split("-");
+              return { x: Number(year), group: answer, y: count };
+            });
+          }
 
-            return {
-              x: Number(year),
-              group: answer,
-              y: count,
-            };
-          });
-      
           const { series, yCategories } = useBubbleDataGeneric(items);
           chartContent = (
             <BubbleChart
@@ -195,22 +216,45 @@ export const QuestionsCharts = ({
               yaxisText=""
             />
           );
+
+        } else if (
+          (type === "Item Table" || type === "Tabela por Item") &&
+          question.questionType === "PICK_MANY"
+        ) {
+          setTablePage("Graphics-FormQuestions");
+          chartContent = (
+            <PickManyItemTable
+              data={filteredAnswer}
+              options={question.options ?? []}
+              studyIds={filteredStudies.map((s) => s.studyReviewId)}
+            />
+          );
+
         } else {
-          if(question.questionType === "TEXTUAL") {
+          if (question.questionType === "TEXTUAL") {
             setTablePage("Graphics-TextualQuestion");
-            
-            const questionId = question.questionId
-
-            const textualStudies = filteredStudies.filter(
-              (study) =>
-                (study as any).formAnswers?.[question.questionId] !== undefined ||
-                (study as any).robAnswers?.[question.questionId] !== undefined
+            chartContent = (
+              <TextualTable
+                columnsVisible={columnsVisible}
+                articles={filteredStudies.filter(
+                  (study) =>
+                    (study as any).formAnswers?.[question.questionId] !==
+                      undefined ||
+                    (study as any).robAnswers?.[question.questionId] !==
+                      undefined
+                )}
+                sortConfig={null}
+                questionId={question.questionId}
+              />
             );
-
-            chartContent = <TextualTable columnsVisible={columnsVisible} articles={textualStudies} sortConfig={null} questionId={questionId} />
           } else {
             setTablePage("Graphics-FormQuestions");
-            chartContent = <QuestionsTable columnsVisible={columnsVisible} data={filteredAnswer} />;
+            chartContent = (
+              <QuestionsTable
+                columnsVisible={columnsVisible}
+                data={filteredAnswer}
+              />
+            );
           }
         }
 
@@ -219,9 +263,7 @@ export const QuestionsCharts = ({
             <Text mb={2} ml="2rem" fontWeight="bold">
               {description}
             </Text>
-            <Box w="100%">
-              {chartContent}
-            </Box>
+            <Box w="100%">{chartContent}</Box>
           </Box>
         );
       })}

--- a/src/locales/en/review/summarization-graphics.json
+++ b/src/locales/en/review/summarization-graphics.json
@@ -55,7 +55,7 @@
     },
     "questionsTable": {
         "answer": "Answer",
-        "studies": "Studies",
+        "studies": "Study ID",
         "total": "Total",
         "percentage": "Percentage of Total"
     }

--- a/src/locales/en/review/summarization-graphics.json
+++ b/src/locales/en/review/summarization-graphics.json
@@ -34,7 +34,8 @@
             "barChart": "Bar Chart",
             "bubbleChart": "Bubble Chart",
             "lineChart": "Line Chart",
-            "table": "Table"
+            "table": "Table",
+            "itemTable": "Item Table"
         }
     },
     "noDataMessage": {
@@ -54,7 +55,7 @@
     },
     "questionsTable": {
         "answer": "Answer",
-        "studies": "Study ID",
+        "studies": "Studies",
         "total": "Total",
         "percentage": "Percentage of Total"
     }

--- a/src/locales/pt/review/summarization-graphics.json
+++ b/src/locales/pt/review/summarization-graphics.json
@@ -39,7 +39,8 @@
             "barChart": "Gráfico de Barras",
             "bubbleChart": "Gráfico de Bolhas",
             "lineChart": "Gráfico de Linhas",
-            "table": "Tabela"
+            "table": "Tabela",
+            "itemTable": "Tabela por Item"
         }
     },
     "noDataMessage": {
@@ -59,7 +60,7 @@
     },
     "questionsTable": {
         "answer": "Resposta",
-        "studies": "ID do Estudo",
+        "studies": "Estudos",
         "total": "Total",
         "percentage": "Percentual do Total"
     }

--- a/src/locales/pt/review/summarization-graphics.json
+++ b/src/locales/pt/review/summarization-graphics.json
@@ -60,7 +60,7 @@
     },
     "questionsTable": {
         "answer": "Resposta",
-        "studies": "Estudos",
+        "studies": "ID do Estudo",
         "total": "Total",
         "percentage": "Percentual do Total"
     }


### PR DESCRIPTION
## Feat: Visualização dinâmica para questões do tipo Pick Many
Implementa a renderização condicional para o tipo de questão PICK_MANY na seção de Questões do Formulário.
Alterações:

- QuestionsCharts — adiciona bloco PICK_MANY com renderização de Gráfico de Barras, Gráfico de Bolhas, Tabela por Item e Tabela Agregada
- PickManyItemTable — novo componente: uma linha por estudo, uma coluna por item selecionável (✓/✗)
- useGraphicsState — expande os tipos permitidos para PICK_MANY incluindo Gráfico de Bolhas e Tabela por Item
- buildQuestionsCsv — exportação da Tabela por Item gera layout por artigo (Yes/No por opção); demais tipos mantêm layout agregado
- ChartRenderer / FormQuestionsRenderer — conecta columnsVisible e setTablePage na cadeia de componentes
pt-BR.json / en-US.json — adiciona chave de tradução itemTable