### PR TITLE
Mz fix custom question codes

### DIFF
--- a/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/DropdownList/index.tsx
+++ b/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/DropdownList/index.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "react-i18next";
 import SelectInput from "@components/common/inputs/SelectInput";
 
 // Utils
-import { capitalize } from "@features/shared/utils/helpers/formatters/CapitalizeText";
+import { renderQuestionLabel } from "../helpers";
 
 // Styles
 import { container, label } from "../styles";
@@ -38,7 +38,7 @@ export default function DropdownList({
 
   return (
     <FormControl sx={container} isInvalid={isInvalid}>
-      <FormLabel sx={label}>{capitalize(question)}</FormLabel>
+      <FormLabel sx={label}>{renderQuestionLabel(question)}</FormLabel>
       <SelectInput
         names={[...options]}
         values={[...options]}

--- a/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/LabeledList/index.tsx
+++ b/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/LabeledList/index.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "react-i18next";
 import SelectInput from "@components/common/inputs/SelectInput";
 
 // Utils
-import { capitalize } from "@features/shared/utils/helpers/formatters/CapitalizeText";
+import { renderQuestionLabel } from "../helpers";
 
 // Styles
 import { container, label } from "../styles";
@@ -54,7 +54,7 @@ export default function LabeledList({
 
   return (
     <FormControl sx={container} isInvalid={isInvalid}>
-      <FormLabel sx={label}>{capitalize(question)}</FormLabel>
+      <FormLabel sx={label}>{renderQuestionLabel(question)}</FormLabel>
       <SelectInput
         names={options}
         values={options}

--- a/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/MultiSelectionList/index.tsx
+++ b/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/MultiSelectionList/index.tsx
@@ -9,7 +9,7 @@ import {
 } from "@chakra-ui/react";
 
 // Utils
-import { capitalize } from "@features/shared/utils/helpers/formatters/CapitalizeText";
+import { renderQuestionLabel } from "../helpers";
 
 // Styles
 import { container, label } from "../styles";
@@ -45,7 +45,7 @@ export default function MultiSelectionList({
 
   return (
     <FormControl sx={container} isInvalid={isInvalid}>
-      <FormLabel sx={label}>{capitalize(question)}</FormLabel>
+      <FormLabel sx={label}>{renderQuestionLabel(question)}</FormLabel>
       <CheckboxGroup value={selected} onChange={handleChange}>
         <Box
           display="flex"

--- a/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/NumberScale/index.tsx
+++ b/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/NumberScale/index.tsx
@@ -13,7 +13,7 @@ import {
 import { useTranslation } from "react-i18next";
 
 // Utils
-import { capitalize } from "@features/shared/utils/helpers/formatters/CapitalizeText";
+import { renderQuestionLabel } from "../helpers";
 
 // Styles
 import { container, label } from "../styles";
@@ -62,7 +62,7 @@ export default function NumberScale({
 
   return (
     <FormControl sx={container} isInvalid={isInvalid}>
-      <FormLabel sx={label}>{capitalize(question)}</FormLabel>
+      <FormLabel sx={label}>{renderQuestionLabel(question)}</FormLabel>
       <Box display="flex" flexDirection="column" gap="1rem">
         <RadioGroup
           sx={radiosGroup}

--- a/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/Textual/index.tsx
+++ b/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/Textual/index.tsx
@@ -4,7 +4,7 @@ import { FormControl, FormLabel, Textarea } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 
 // Utils
-import { capitalize } from "@features/shared/utils/helpers/formatters/CapitalizeText";
+import { renderQuestionLabel } from "../helpers";
 
 // Styles
 import { responseArea } from "./styles";
@@ -35,7 +35,7 @@ export default function TextualResponse({
 
   return (
     <FormControl sx={container} isInvalid={isInvalid}>
-      <FormLabel sx={label}>{capitalize(question)}</FormLabel>
+      <FormLabel sx={label}>{renderQuestionLabel(question)}</FormLabel>
       <Textarea
         value={response}
         onChange={handleChange}

--- a/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/helpers.tsx
+++ b/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/helpers.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from "react";
+import { Box } from "@chakra-ui/react";
+import { capitalize } from "@features/shared/utils/helpers/formatters/CapitalizeText";
+
+export function renderQuestionLabel(question: string): ReactNode {
+  const formattedQuestion = capitalize(question);
+  const separatorIndex = formattedQuestion.indexOf(":");
+
+  if (separatorIndex < 0) {
+    return <Box as="span">{formattedQuestion}</Box>;
+  }
+
+  const id = formattedQuestion.slice(0, separatorIndex);
+  const rest = formattedQuestion.slice(separatorIndex);
+
+  return (
+    <>
+      <Box as="span" fontWeight="semibold">
+        {id}
+      </Box>
+      <Box as="span">{rest}</Box>
+    </>
+  );
+}

--- a/src/features/review/execution-extraction/factory/CreateResponseComponents/index.tsx
+++ b/src/features/review/execution-extraction/factory/CreateResponseComponents/index.tsx
@@ -33,7 +33,7 @@ export default function CreateResponseComponent({
     TEXTUAL: (
       <TextualResponse
         key={question.code}
-        question={question.description}
+        question={`${question.code}: ${question.description}`}
         answer={answer.value as string}
         isInvalid={isInvalid}
         onResponse={(response) =>
@@ -47,7 +47,7 @@ export default function CreateResponseComponent({
     NUMBERED_SCALE: (
       <NumberScale
         key={question.code}
-        question={question.description}
+        question={`${question.code}: ${question.description}`}
         answer={answer.value as string}
         minValue={question.lower}
         maxValue={question.higher}
@@ -63,7 +63,7 @@ export default function CreateResponseComponent({
     LABELED_SCALE: (
       <LabeledList
         key={question.code}
-        question={question.description}
+        question={`${question.code}: ${question.description}`}
         scales={question.scales}
         answer={answer.value as { name: string; value: number }}
         isInvalid={isInvalid}
@@ -78,7 +78,7 @@ export default function CreateResponseComponent({
     PICK_LIST: (
       <DropdownList
         key={question.code}
-        question={question.description}
+        question={`${question.code}: ${question.description}`}
         options={question.options || []}
         answer={answer.value as string}
         isInvalid={isInvalid}
@@ -93,7 +93,7 @@ export default function CreateResponseComponent({
     PICK_MANY: (
       <MultiSelectionList
         key={question.code}
-        question={question.description}
+        question={`${question.code}: ${question.description}`}
         options={question.options || []}
         answer={answer.value as string[]}
         isInvalid={isInvalid}


### PR DESCRIPTION
### Corrigir a exibição das questões para que utilizem o código customizado definido anteriormente, em vez do padrão fixo (EQ1, RBQ1, etc.)

### Alteração
<img width="558" height="762" alt="image" src="https://github.com/user-attachments/assets/158f83fd-6f55-4d5e-9574-df9744766f72" />

### Local da Alteração
<img width="224" height="926" alt="image" src="https://github.com/user-attachments/assets/c0a23a0d-2932-4960-ba7c-d9d23df274b9" />
