### PR TITLE
fix(identification): delete database card by removing sessions and updating protocol sources

### DIFF
--- a/src/features/review/execution-identification/pages/Identification/index.tsx
+++ b/src/features/review/execution-identification/pages/Identification/index.tsx
@@ -1,26 +1,22 @@
-// External library
 import { Box, Flex } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 
-// Components
 import DataBaseRequired from "../../../shared/components/structure/DataBaseRequired";
 import DataBaseCard from "./subcomponents/cards/DatabaseCard";
 import Header from "../../../../../components/structure/Header/Header";
 import FlexLayout from "../../../../../components/structure/Flex/Flex";
 import CardDefault from "@components/common/cards";
 
-// Service
 import useFetchDataBases from "../../../shared/services/useFetchDataBases";
 
-// Styles
 import { conteiner, dataBaseconteiner } from "./styles";
 
 export default function Identification() {
-  const { databases } = useFetchDataBases();
+  const { databases, mutate: mutateDatabases } = useFetchDataBases();
 
-  const { t } = useTranslation("review/execution-identification")
+  const { t } = useTranslation("review/execution-identification");
 
-  const databaseListIsEmpty = databases.length == 0;
+  const databaseListIsEmpty = databases.length === 0;
 
   return (
     <FlexLayout navigationType="Accordion">
@@ -45,7 +41,11 @@ export default function Identification() {
           {databaseListIsEmpty && <DataBaseRequired />}
           <Box sx={dataBaseconteiner}>
             {databases.map((data, index) => (
-              <DataBaseCard text={data} key={index} />
+              <DataBaseCard
+                text={data}
+                key={index}
+                mutateDatabases={mutateDatabases}
+              />
             ))}
           </Box>
         </Box>

--- a/src/features/review/execution-identification/pages/Identification/subcomponents/cards/DatabaseCard/index.tsx
+++ b/src/features/review/execution-identification/pages/Identification/subcomponents/cards/DatabaseCard/index.tsx
@@ -22,6 +22,7 @@ import {
 import { AddIcon } from "@chakra-ui/icons";
 import { AiOutlineDelete, AiOutlineEdit, AiOutlineEye } from "react-icons/ai";
 import { useTranslation } from "react-i18next";
+import { KeyedMutator } from "swr";
 
 import DeleteDatabaseModal from "../../modals/DeleteDatabase";
 import IdentificationModal from "../../modals/IdentificationModal";
@@ -31,9 +32,10 @@ import UseDeleteSession from "../../../../../services/useDeleteSession";
 
 interface DatabaseCardProps {
   text: string;
+  mutateDatabases: KeyedMutator<string[]>;
 }
 
-export default function DataBaseCard({ text }: DatabaseCardProps) {
+export default function DataBaseCard({ text, mutateDatabases }: DatabaseCardProps) {
   const navigate = useNavigate();
   const { t } = useTranslation("review/execution-identification");
 
@@ -94,17 +96,15 @@ export default function DataBaseCard({ text }: DatabaseCardProps) {
             flexDirection="column"
             _hover={{ bg: "transparent" }}
           >
-            
             <Flex
               w="100%"
-              minH="10px" 
+              minH="10px"
               bg="#263C56"
               justifyContent="space-between"
               alignItems="center"
-              p="1.5rem 1.5rem" 
+              p="1.5rem 1.5rem"
             >
               <Flex flex="1" alignItems="center" gap="0.75rem">
-                
                 <Text
                   fontSize="lg"
                   fontWeight="bold"
@@ -202,9 +202,7 @@ export default function DataBaseCard({ text }: DatabaseCardProps) {
                         _even={{ bg: "#E2E8F0" }}
                       >
                         <Td color="gray.700">
-                          {new Date(session.timestamp).toLocaleDateString(
-                            "pt-BR",
-                          )}
+                          {new Date(session.timestamp).toLocaleDateString("pt-BR")}
                         </Td>
                         <Td color="gray.700">
                           {session.numberOfRelatedStudies}
@@ -217,9 +215,9 @@ export default function DataBaseCard({ text }: DatabaseCardProps) {
                               size="sm"
                               bg="transparent"
                               color="gray.600"
-                              borderRadius="md" 
+                              borderRadius="md"
                               transition="all 0.2s"
-                              _hover={{ bg: "blue.100", color: "blue.700" }} 
+                              _hover={{ bg: "blue.100", color: "blue.700" }}
                               onClick={() =>
                                 handleNavigateToSession(
                                   session.id,
@@ -233,7 +231,7 @@ export default function DataBaseCard({ text }: DatabaseCardProps) {
                               size="sm"
                               bg="transparent"
                               color="gray.600"
-                              borderRadius="md" 
+                              borderRadius="md"
                               transition="all 0.2s"
                               _hover={{ bg: "gray.200", color: "#263C56" }}
                               onClick={() =>
@@ -246,9 +244,9 @@ export default function DataBaseCard({ text }: DatabaseCardProps) {
                               size="sm"
                               bg="transparent"
                               color="red.500"
-                              borderRadius="md" 
+                              borderRadius="md"
                               transition="all 0.2s"
-                              _hover={{ bg: "red.100", color: "red.700" }} 
+                              _hover={{ bg: "red.100", color: "red.700" }}
                               onClick={() => handleDeleteSession(session.id)}
                             />
                           </Flex>
@@ -280,6 +278,7 @@ export default function DataBaseCard({ text }: DatabaseCardProps) {
           action={deleteModal}
           sessions={data}
           mutate={mutate}
+          mutateDatabases={mutateDatabases}
           databaseName={text}
         />
       )}

--- a/src/features/review/execution-identification/pages/Identification/subcomponents/modals/DeleteDatabase/index.tsx
+++ b/src/features/review/execution-identification/pages/Identification/subcomponents/modals/DeleteDatabase/index.tsx
@@ -18,11 +18,11 @@ import {
   Divider,
 } from "@chakra-ui/react";
 
-// Icon
 import { IoIosWarning } from "react-icons/io";
 
 import { KeyedMutator } from "swr";
 import UseDeleteSession from "@features/review/execution-identification/services/useDeleteSession";
+import Axios from "../../../../../../../../infrastructure/http/axiosClient";
 
 interface DeleteDatabaseModalProps {
   show: (value: boolean) => void;
@@ -37,33 +37,25 @@ interface DeleteDatabaseModalProps {
     source: string;
     numberOfRelatedStudies: number;
   }[];
-  // setSessions?:Dispatch<SetStateAction<{ id: string; systematicStudyd: string; userId: string; searchString: string; additionalInfo: string; timestamp: string; source: string; numberOfRelatedStudies: number; }[]>>;
-  mutate: KeyedMutator<
-    {
-      id: string;
-      systematicStudyd: string;
-      userId: string;
-      searchString: string;
-      additionalInfo: string;
-      timestamp: string;
-      source: string;
-      numberOfRelatedStudies: number;
-    }[]
-  >;
+  mutate: KeyedMutator<any[]>;
+  mutateDatabases: KeyedMutator<string[]>;
   databaseName: string;
 }
 
-// function DeleteDatabaseModal({ show, sessions, setSessions, databaseName}: DeleteDatabaseModalProps) {
 function DeleteDatabaseModal({
   show,
   sessions,
   mutate,
+  mutateDatabases,
   databaseName,
 }: DeleteDatabaseModalProps) {
   const { isOpen, onClose, onOpen } = useDisclosure();
   const [nameOfDatabase, setNameOfDatabase] = useState<string>("");
+  const [isDeleting, setIsDeleting] = useState(false);
   const toast = useToaster();
   const { t } = useTranslation("review/execution-identification");
+  const id = localStorage.getItem("systematicReviewId");
+  const protocolUrl = `systematic-study/${id}/protocol`;
 
   useEffect(() => {
     onOpen();
@@ -74,39 +66,67 @@ function DeleteDatabaseModal({
     onClose();
   };
 
-  const isDatabaseNameCorrect = (name: string) => {
-    return nameOfDatabase.trim() !== name.trim();
+  const isDatabaseNameCorrect = () => {
+    return nameOfDatabase.trim() === databaseName.trim();
+  };
+
+  const removeDatabaseFromProtocol = async () => {
+    const response = await Axios.get(protocolUrl);
+    const currentSources: string[] =
+      response.data.content.informationSources ?? [];
+
+    const updatedSources = currentSources.filter(
+      (source) => source.toUpperCase() !== databaseName.toUpperCase()
+    );
+
+    await Axios.put(protocolUrl, { informationSources: updatedSources });
   };
 
   const deleteAllReferences = async () => {
-    if (isDatabaseNameCorrect(nameOfDatabase)) {
+    if (!isDatabaseNameCorrect()) {
       toast({
         title: t("dataBaseCard.deleteDatabaseModal.toasts.incorrectName.title"),
-        description: t("dataBaseCard.deleteDatabaseModal.toasts.incorrectName.description"),
+        description: t(
+          "dataBaseCard.deleteDatabaseModal.toasts.incorrectName.description"
+        ),
         status: "error",
       });
       return;
     }
 
+    setIsDeleting(true);
+
     try {
-      sessions.map(async (study) => {
-        await UseDeleteSession({ sessionId: study.id, mutate });
-      });
+      await Promise.all(
+        sessions.map((session) =>
+          UseDeleteSession({ sessionId: session.id, mutate })
+        )
+      );
+
+      await removeDatabaseFromProtocol();
+
+      await mutateDatabases();
 
       toast({
         title: t("dataBaseCard.deleteDatabaseModal.toasts.success.title"),
-        description: t("dataBaseCard.deleteDatabaseModal.toasts.success.description"),
+        description: t(
+          "dataBaseCard.deleteDatabaseModal.toasts.success.description"
+        ),
         status: "success",
       });
-      mutate();
+
       handleClose();
     } catch (err) {
-      console.log(err);
+      console.error(err);
       toast({
         title: t("dataBaseCard.deleteDatabaseModal.toasts.catch.title"),
-        description: t("dataBaseCard.deleteDatabaseModal.toasts.catch.description"),
+        description: t(
+          "dataBaseCard.deleteDatabaseModal.toasts.catch.description"
+        ),
         status: "error",
       });
+    } finally {
+      setIsDeleting(false);
     }
   };
 
@@ -133,12 +153,12 @@ function DeleteDatabaseModal({
           <ModalCloseButton onClick={handleClose} />
         </ModalHeader>
         <ModalBody>
-          <Flex>
-            {t("dataBaseCard.deleteDatabaseModal.message")}
-          </Flex>
+          <Flex>{t("dataBaseCard.deleteDatabaseModal.message")}</Flex>
           <FormControl mt={4} mb={3}>
             <FormLabel>
-              {t("dataBaseCard.deleteDatabaseModal.label1")+databaseName+t("dataBaseCard.deleteDatabaseModal.label2")}
+              {t("dataBaseCard.deleteDatabaseModal.label1") +
+                databaseName +
+                t("dataBaseCard.deleteDatabaseModal.label2")}
             </FormLabel>
             <Input
               onChange={(e) => setNameOfDatabase(e.target.value)}
@@ -157,6 +177,7 @@ function DeleteDatabaseModal({
               color={"#EBF0F3"}
               boxShadow="sm"
               _hover={{ bg: "#2A4A6D", boxShadow: "md" }}
+              isDisabled={isDeleting}
             >
               {t("dataBaseCard.deleteDatabaseModal.cancel")}
             </Button>
@@ -166,7 +187,8 @@ function DeleteDatabaseModal({
               color={"#EBF0F3"}
               boxShadow="sm"
               _hover={{ bg: "#2A4A6D", boxShadow: "md" }}
-              isDisabled={isDatabaseNameCorrect(databaseName)}
+              isDisabled={!isDatabaseNameCorrect() || isDeleting}
+              isLoading={isDeleting}
             >
               {t("dataBaseCard.deleteDatabaseModal.remove")}
             </Button>

--- a/src/features/review/shared/services/useFetchDataBases.ts
+++ b/src/features/review/shared/services/useFetchDataBases.ts
@@ -1,25 +1,23 @@
-import { useEffect, useState } from "react";
+import useSWR from "swr";
 import Axios from "../../../../infrastructure/http/axiosClient";
 
 const useFetchDataBases = () => {
-  const [databases, setdatabase] = useState<string[]>([]);
   const id = localStorage.getItem("systematicReviewId");
+  const path = `systematic-study/${id}/protocol`;
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        let response = await Axios.get(`systematic-study/${id}/protocol`, {
-          withCredentials: true,
-        });
-        setdatabase(response.data.content.informationSources);
-      } catch (error) {
-        console.error("Erro ao buscar os dados:", error);
-      }
-    };
+  const { data, error, isLoading, mutate } = useSWR(path, async () => {
+    const response = await Axios.get(path, { withCredentials: true });
+    return response.data.content.informationSources as string[];
+  }, {
+    revalidateOnFocus: true,
+    revalidateOnMount: true,
+  });
 
-    fetchData();
-  }, []);
-
-  return { databases };
+  return {
+    databases: data || [],
+    error,
+    isLoading,
+    mutate,
+  };
 };
 export default useFetchDataBases;


### PR DESCRIPTION
## fix: Remoção completa de databases na tela de Identificação
Corrige o comportamento onde ao deletar uma database apenas as sessões eram removidas, mas o card permanecia na tela.
Alterações:

- useFetchDataBases — convertido de useEffect/useState para SWR, expondo mutate para revalidação sob demanda
- Identification/index.tsx — extrai mutate do hook e passa como mutateDatabases para cada DataBaseCard
- DatabaseCard/index.tsx — recebe mutateDatabases via prop e repassa para o DeleteDatabaseModal
- DeleteDatabaseModal/index.tsx — corrigido .map(async) para Promise.all, adicionada chamada ao PUT /protocol removendo a database do informationSources, e mutateDatabases chamado ao final para remover o card da tela