### PR TITLE
fix: resolve UX issues with criteria selection and extraction status …

### DIFF
--- a/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
+++ b/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
@@ -134,8 +134,6 @@ export default function ButtonsForSelection({
 
   if (!criteriaGroupDataMap["INCLUSION"] || !criteriaGroupDataMap["EXCLUSION"]) return null;
 
-  const isInclusionActive = criteriaOptions.INCLUSION.isActive;
-  const isExclusionActive = criteriaOptions.EXCLUSION.isActive;
   const isDuplicated = currentArticle.extractionStatus === "DUPLICATED" || currentArticle.selectionStatus === "DUPLICATED";
   const isUniqueArticle = articles.length === 1;
 
@@ -191,13 +189,13 @@ export default function ButtonsForSelection({
     INCLUSION: {
       label: "Include",
       description: "Add inclusion criteria",
-      isDisabled: criteriaGroupDataMap["INCLUSION"].data.length === 0 || isExclusionActive || isDuplicated,
+      isDisabled: criteriaGroupDataMap["INCLUSION"].data.length === 0 || isDuplicated,
       options: criteriaGroupDataMap["INCLUSION"].data,
     },
     EXCLUSION: {
       label: "Exclude",
       description: "Add exclusion criteria",
-      isDisabled: criteriaGroupDataMap["EXCLUSION"].data.length === 0 || isInclusionActive || isDuplicated,
+      isDisabled: criteriaGroupDataMap["EXCLUSION"].data.length === 0 || isDuplicated,
       options: criteriaGroupDataMap["EXCLUSION"].data,
     },
   };

--- a/src/features/review/shared/hooks/useComboBoxSelection.ts
+++ b/src/features/review/shared/hooks/useComboBoxSelection.ts
@@ -37,8 +37,7 @@ const useComboBoxSelection = ({
               status,
             });
 
-            const extractionStatus =
-              status === "INCLUDED" ? "UNCLASSIFIED" : status;
+            const extractionStatus = status;
 
             await UseChangeStudyExtractionStatus({
               studyReviewId: [selectedArticleReview],

--- a/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
+++ b/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
@@ -113,17 +113,17 @@ export default function useFetchAllCriteriasByArticle({
     const currentChecked = criteria?.[OPTION_TO_GET_KEY[key]] || [];
     const oppositeChecked = criteria?.[OPTION_TO_GET_KEY[oppositeKey]] || [];
 
-    if (newValue && oppositeChecked.length > 0) return;
-
     const newChecked = newValue
       ? [...currentChecked, optionText]
       : currentChecked.filter((c) => c !== optionText);
 
+    const newOppositeChecked = newValue ? [] : oppositeChecked;
+
     const optimisticData = {
       inclusionCriteria:
-        key === "INCLUSION" ? newChecked : criteria?.inclusionCriteria || [],
+        key === "INCLUSION" ? newChecked : newOppositeChecked,
       exclusionCriteria:
-        key === "EXCLUSION" ? newChecked : criteria?.exclusionCriteria || [],
+        key === "EXCLUSION" ? newChecked : newOppositeChecked,
     };
 
     const status: StatusValue =
@@ -137,8 +137,7 @@ export default function useFetchAllCriteriasByArticle({
       await mutate(
         async () => {
           if (page === "Selection") {
-            const extractionStatus: StatusValue =
-              status === "INCLUDED" ? "UNCLASSIFIED" : status;
+            const extractionStatus: StatusValue = status;
 
             await UseChangeStudyExtractionStatus({
               studyReviewId: [selectedArticleReview],
@@ -161,6 +160,8 @@ export default function useFetchAllCriteriasByArticle({
 
           if (!newValue) {
             await revertCriterionState([optionText]);
+          } else if (oppositeChecked.length > 0) {
+            await revertCriterionState(oppositeChecked);
           }
 
           if (reloadArticles) await reloadArticles();


### PR DESCRIPTION
## FIX

This PR addresses critical UX issues within the article review flow (Selection and Extraction phases). Previously, the state machine for the criteria selection buttons (Include/Exclude) had overly strict locks that forced users to reset the entire article just to change its status.

. Go to the **Selection** phase and mark an article as **Included** by selecting an inclusion criterion.
. Navigate to the **Extraction** phase and verify that the article's status badge correctly displays as **Included**