### PR TITLE
fix(selection): prevent stale criteria state from disabling buttons on unclassified articles

### DIFF
--- a/src/features/review/shared/services/useCriteriaForFocusedArticle.tsx
+++ b/src/features/review/shared/services/useCriteriaForFocusedArticle.tsx
@@ -7,7 +7,6 @@ import useToaster from "@components/feedback/Toaster";
 // Service
 import Axios from "../../../../infrastructure/http/axiosClient";
 
-// Types
 interface HttpResponse {
   inclusionCriteria: string[];
   exclusionCriteria: string[];
@@ -24,21 +23,26 @@ export default function useFetchCriteriaForFocusedArticle({
   const toast = useToaster();
 
   const path =
-    id && articleId
+    id && articleId && articleId !== -1
       ? `systematic-study/${id}/report/study-review/${articleId}/criteria`
       : null;
 
-  const { data, isLoading, error, mutate } = useSWR(path, fetchAllCriteria, {
-    revalidateOnFocus: false,
-    onError: () => {
-      toast({
-        title: "Erro ao carregar critérios",
-        description:
-          "Não foi possível buscar os critérios deste artigo. Os dados exibidos podem estar desatualizados.",
-        status: "error",
-      });
-    },
-  });
+  const { data, isLoading, error, mutate } = useSWR(
+    path ? [path, articleId] : null,
+    fetchAllCriteria,
+    {
+      revalidateOnFocus: false,
+      keepPreviousData: false,
+      onError: () => {
+        toast({
+          title: "Erro ao carregar critérios",
+          description:
+            "Não foi possível buscar os critérios deste artigo. Os dados exibidos podem estar desatualizados.",
+          status: "error",
+        });
+      },
+    }
+  );
 
   async function fetchAllCriteria() {
     try {

--- a/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
+++ b/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
@@ -65,7 +65,7 @@ export default function useFetchAllCriteriasByArticle({
   const selectedArticleReview = studiesContext?.selectedArticleReview ?? -1;
   const toast = useToaster();
 
-  const { criteria, mutate } = useFetchCriteriaForFocusedArticle({
+  const { criteria, isLoading, mutate } = useFetchCriteriaForFocusedArticle({
     articleId: selectedArticleReview,
   });
 
@@ -74,8 +74,10 @@ export default function useFetchAllCriteriasByArticle({
   const { revertCriterionState } = useRevertCriterionState({ page });
 
   const criterias = useMemo<CriteiriaProps>(() => {
-    const checkedInclusion = criteria?.inclusionCriteria || [];
-    const checkedExclusion = criteria?.exclusionCriteria || [];
+    if (isLoading || !criteria) return CRITERIA_FALLBACK;
+
+    const checkedInclusion = criteria.inclusionCriteria || [];
+    const checkedExclusion = criteria.exclusionCriteria || [];
 
     const inclusionMapped: OptionProps[] = inclusion.map((text) => ({
       text,
@@ -99,7 +101,7 @@ export default function useFetchAllCriteriasByArticle({
         },
       },
     };
-  }, [inclusion, exclusion, criteria]);
+  }, [inclusion, exclusion, criteria, isLoading]);
 
   const handlerUpdateCriteriasStructure = async (
     key: OptionType,
@@ -186,7 +188,7 @@ export default function useFetchAllCriteriasByArticle({
 
   const resetLocalCriterias = async () => {
     if (selectedArticleReview === -1) return;
-    
+
     await mutate(
       (currentData: any) => ({
         ...currentData,


### PR DESCRIPTION
## fix: Correção de critérios desabilitados em artigos unclassified
### Corrige bug intermitente onde artigos UNCLASSIFIED apareciam com os botões de critérios desabilitados ao navegar entre artigos.
Alterações:

- useCriteriaForFocusedArticle — chave do SWR alterada para [path, articleId] garantindo cache separado por artigo, e keepPreviousData: false para limpar dados do artigo anterior imediatamente ao trocar
- useFetchAllCriteriasByArticle — adicionado isLoading como dependência do useMemo, retornando CRITERIA_FALLBACK com isActive: false enquanto os critérios do novo artigo carregam, evitando que o estado do artigo anterior desabilite os botões do próximo