### PR TITLE
Cp fix criteria selection ux

### DIFF
--- a/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
+++ b/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
@@ -134,8 +134,6 @@ export default function ButtonsForSelection({
 
   if (!criteriaGroupDataMap["INCLUSION"] || !criteriaGroupDataMap["EXCLUSION"]) return null;
 
-  const isInclusionActive = criteriaOptions.INCLUSION.isActive;
-  const isExclusionActive = criteriaOptions.EXCLUSION.isActive;
   const isDuplicated = currentArticle.extractionStatus === "DUPLICATED" || currentArticle.selectionStatus === "DUPLICATED";
   const isUniqueArticle = articles.length === 1;
 
@@ -191,13 +189,13 @@ export default function ButtonsForSelection({
     INCLUSION: {
       label: "Include",
       description: "Add inclusion criteria",
-      isDisabled: criteriaGroupDataMap["INCLUSION"].data.length === 0 || isExclusionActive || isDuplicated,
+      isDisabled: criteriaGroupDataMap["INCLUSION"].data.length === 0 || isDuplicated,
       options: criteriaGroupDataMap["INCLUSION"].data,
     },
     EXCLUSION: {
       label: "Exclude",
       description: "Add exclusion criteria",
-      isDisabled: criteriaGroupDataMap["EXCLUSION"].data.length === 0 || isInclusionActive || isDuplicated,
+      isDisabled: criteriaGroupDataMap["EXCLUSION"].data.length === 0 || isDuplicated,
       options: criteriaGroupDataMap["EXCLUSION"].data,
     },
   };

--- a/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
+++ b/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
@@ -91,8 +91,22 @@ export default function ButtonsForSelection({
 
   const handleFullReset = async () => {
     if (!currentArticleId) return;
-    await handleResetStatusToUnclassified(currentArticleId, historicalCriteria);
+    const activeInclusion = fetchedCriterias?.options?.INCLUSION?.content
+      .filter((c) => c.isChecked)
+      .map((c) => c.text) || [];
+    
+    const activeExclusion = fetchedCriterias?.options?.EXCLUSION?.content
+      .filter((c) => c.isChecked)
+      .map((c) => c.text) || [];
+    
+    const currentActiveCriteria = [...activeInclusion, ...activeExclusion];
+
+    const criteriaToClear = currentActiveCriteria.length > 0 ? currentActiveCriteria : historicalCriteria;
+
+    await handleResetStatusToUnclassified(currentArticleId, criteriaToClear);
+    
     resetLocalCriterias();
+    
     if (page === "Selection") {
       setHistoricalCriteria([]);
     }

--- a/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
+++ b/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
@@ -134,6 +134,8 @@ export default function ButtonsForSelection({
 
   if (!criteriaGroupDataMap["INCLUSION"] || !criteriaGroupDataMap["EXCLUSION"]) return null;
 
+  const isInclusionActive = criteriaOptions.INCLUSION.isActive;
+  const isExclusionActive = criteriaOptions.EXCLUSION.isActive;
   const isDuplicated = currentArticle.extractionStatus === "DUPLICATED" || currentArticle.selectionStatus === "DUPLICATED";
   const isUniqueArticle = articles.length === 1;
 
@@ -189,13 +191,13 @@ export default function ButtonsForSelection({
     INCLUSION: {
       label: "Include",
       description: "Add inclusion criteria",
-      isDisabled: criteriaGroupDataMap["INCLUSION"].data.length === 0 || isDuplicated,
+      isDisabled: criteriaGroupDataMap["INCLUSION"].data.length === 0 || isExclusionActive || isDuplicated,
       options: criteriaGroupDataMap["INCLUSION"].data,
     },
     EXCLUSION: {
       label: "Exclude",
       description: "Add exclusion criteria",
-      isDisabled: criteriaGroupDataMap["EXCLUSION"].data.length === 0 || isDuplicated,
+      isDisabled: criteriaGroupDataMap["EXCLUSION"].data.length === 0 || isInclusionActive || isDuplicated,
       options: criteriaGroupDataMap["EXCLUSION"].data,
     },
   };

--- a/src/features/review/shared/hooks/useComboBoxSelection.ts
+++ b/src/features/review/shared/hooks/useComboBoxSelection.ts
@@ -37,8 +37,7 @@ const useComboBoxSelection = ({
               status,
             });
 
-            const extractionStatus =
-              status === "INCLUDED" ? "UNCLASSIFIED" : status;
+            const extractionStatus = status;
 
             await UseChangeStudyExtractionStatus({
               studyReviewId: [selectedArticleReview],

--- a/src/features/review/shared/hooks/useComboBoxSelection.ts
+++ b/src/features/review/shared/hooks/useComboBoxSelection.ts
@@ -37,7 +37,8 @@ const useComboBoxSelection = ({
               status,
             });
 
-            const extractionStatus = status;
+            const extractionStatus =
+              status === "INCLUDED" ? "UNCLASSIFIED" : status;
 
             await UseChangeStudyExtractionStatus({
               studyReviewId: [selectedArticleReview],

--- a/src/features/review/shared/hooks/useResetStatus.ts
+++ b/src/features/review/shared/hooks/useResetStatus.ts
@@ -1,6 +1,7 @@
 // Hooks
 import { UseChangeStudySelectionStatus } from "../services/useChangeStudySelectionStatus";
 import { UseChangeStudyExtractionStatus } from "../services/useChangeStudyExtractionStatus";
+import Axios from "../../../../infrastructure/http/axiosClient"; // Adicionado a importação do Axios
 
 //Types
 import { PageLayout } from "../components/structure/LayoutFactory";
@@ -38,6 +39,16 @@ const useResetStatus = ({ page, reloadArticles }: ResetButtonProps) => {
           status: "UNCLASSIFIED",
           criterias: historicalCriteria,
         });
+      }
+      
+      if (historicalCriteria && historicalCriteria.length > 0) {
+        const id = localStorage.getItem("systematicReviewId");
+        if (id) {
+          const path = `systematic-study/${id}/study-review/remove-criteria/${articleId}`;
+          await Axios.patch(path, { criteria: historicalCriteria }).catch(
+            (err) => console.warn("Aviso: Falha ao limpar critérios fisicamente no reset", err)
+          );
+        }
       }
 
       await reloadArticles();

--- a/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
+++ b/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
@@ -115,17 +115,17 @@ export default function useFetchAllCriteriasByArticle({
     const currentChecked = criteria?.[OPTION_TO_GET_KEY[key]] || [];
     const oppositeChecked = criteria?.[OPTION_TO_GET_KEY[oppositeKey]] || [];
 
+    if (newValue && oppositeChecked.length > 0) return;
+
     const newChecked = newValue
       ? [...currentChecked, optionText]
       : currentChecked.filter((c) => c !== optionText);
 
-    const newOppositeChecked = newValue ? [] : oppositeChecked;
-
     const optimisticData = {
       inclusionCriteria:
-        key === "INCLUSION" ? newChecked : newOppositeChecked,
+        key === "INCLUSION" ? newChecked : criteria?.inclusionCriteria || [],
       exclusionCriteria:
-        key === "EXCLUSION" ? newChecked : newOppositeChecked,
+        key === "EXCLUSION" ? newChecked : criteria?.exclusionCriteria || [],
     };
 
     const status: StatusValue =
@@ -139,7 +139,8 @@ export default function useFetchAllCriteriasByArticle({
       await mutate(
         async () => {
           if (page === "Selection") {
-            const extractionStatus: StatusValue = status;
+            const extractionStatus: StatusValue =
+              status === "INCLUDED" ? "UNCLASSIFIED" : status;
 
             await UseChangeStudyExtractionStatus({
               studyReviewId: [selectedArticleReview],
@@ -162,8 +163,6 @@ export default function useFetchAllCriteriasByArticle({
 
           if (!newValue) {
             await revertCriterionState([optionText]);
-          } else if (oppositeChecked.length > 0) {
-            await revertCriterionState(oppositeChecked);
           }
 
           if (reloadArticles) await reloadArticles();

--- a/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
+++ b/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
@@ -139,12 +139,6 @@ export default function useFetchAllCriteriasByArticle({
       await mutate(
         async () => {
           if (page === "Selection") {
-            await UseChangeStudySelectionStatus({
-              studyReviewId: [selectedArticleReview],
-              criterias: newChecked,
-              status,
-            });
-
             const extractionStatus: StatusValue =
               status === "INCLUDED" ? "UNCLASSIFIED" : status;
 
@@ -152,6 +146,12 @@ export default function useFetchAllCriteriasByArticle({
               studyReviewId: [selectedArticleReview],
               criterias: status === "EXCLUDED" ? newChecked : [],
               status: extractionStatus,
+            });
+
+            await UseChangeStudySelectionStatus({
+              studyReviewId: [selectedArticleReview],
+              criterias: newChecked,
+              status,
             });
           } else {
             await UseChangeStudyExtractionStatus({
@@ -188,7 +188,15 @@ export default function useFetchAllCriteriasByArticle({
 
   const resetLocalCriterias = async () => {
     if (selectedArticleReview === -1) return;
-    await mutate();
+    
+    await mutate(
+      (currentData: any) => ({
+        ...currentData,
+        inclusionCriteria: [],
+        exclusionCriteria: [],
+      }),
+      { revalidate: false }
+    );
   };
 
   return {

--- a/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
+++ b/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
@@ -115,17 +115,17 @@ export default function useFetchAllCriteriasByArticle({
     const currentChecked = criteria?.[OPTION_TO_GET_KEY[key]] || [];
     const oppositeChecked = criteria?.[OPTION_TO_GET_KEY[oppositeKey]] || [];
 
-    if (newValue && oppositeChecked.length > 0) return;
-
     const newChecked = newValue
       ? [...currentChecked, optionText]
       : currentChecked.filter((c) => c !== optionText);
 
+    const newOppositeChecked = newValue ? [] : oppositeChecked;
+
     const optimisticData = {
       inclusionCriteria:
-        key === "INCLUSION" ? newChecked : criteria?.inclusionCriteria || [],
+        key === "INCLUSION" ? newChecked : newOppositeChecked,
       exclusionCriteria:
-        key === "EXCLUSION" ? newChecked : criteria?.exclusionCriteria || [],
+        key === "EXCLUSION" ? newChecked : newOppositeChecked,
     };
 
     const status: StatusValue =
@@ -139,8 +139,7 @@ export default function useFetchAllCriteriasByArticle({
       await mutate(
         async () => {
           if (page === "Selection") {
-            const extractionStatus: StatusValue =
-              status === "INCLUDED" ? "UNCLASSIFIED" : status;
+            const extractionStatus: StatusValue = status;
 
             await UseChangeStudyExtractionStatus({
               studyReviewId: [selectedArticleReview],
@@ -163,6 +162,8 @@ export default function useFetchAllCriteriasByArticle({
 
           if (!newValue) {
             await revertCriterionState([optionText]);
+          } else if (oppositeChecked.length > 0) {
+            await revertCriterionState(oppositeChecked);
           }
 
           if (reloadArticles) await reloadArticles();

--- a/src/features/review/shared/services/useRevertCriterionState.tsx
+++ b/src/features/review/shared/services/useRevertCriterionState.tsx
@@ -3,6 +3,8 @@ import Axios from "../../../../infrastructure/http/axiosClient";
 
 // Hooks
 import useFocusedArticle from "../hooks/useFocusedArticle";
+import { useContext } from "react";
+import StudyContext from "../context/StudiesContext";
 
 // Types
 import type { PageLayout } from "../components/structure/LayoutFactory";
@@ -19,13 +21,19 @@ export default function useRevertCriterionState({
   page,
 }: RevertCriterionStateProps) {
   const { articleInFocus } = useFocusedArticle({ page });
-  const articleId = articleInFocus?.studyReviewId || -1;
+  const studiesContext = useContext(StudyContext);
+
+  const articleId =
+    articleInFocus?.studyReviewId ||
+    studiesContext?.selectedArticleReview ||
+    -1;
 
   const revertCriterionState = async (criteria: string[]) => {
     const id = localStorage.getItem("systematicReviewId");
 
     if (!id || articleId === -1) {
-      throw new Error("Invalid systematicReviewId or articleId");
+      console.warn("Invalid IDs, aborting revert silently to prevent UI crash.");
+      return []; 
     }
 
     try {
@@ -34,7 +42,7 @@ export default function useRevertCriterionState({
       return response.data.criteria;
     } catch (error) {
       console.error("Failed to revert criterion state:", error);
-      throw error;
+      return criteria;
     }
   };
 

--- a/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/IncludedStudiesRenderer/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/IncludedStudiesRenderer/index.tsx
@@ -22,6 +22,11 @@ export default function IncludedStudiesRenderer({ filteredStudies, type, chartId
 
   const isTable = type === "Table" || type === "Tabela";
   const isBubble = type === "Bubble Chart" || type === "Gráfico de Bolhas";
+  
+  const bubbleItems: BubbleItem[] = includedStudies.flatMap(study =>
+    study.searchSources.map(src => ({ x: Number(study.year), group: src, y: 1 }))
+  );
+  const { series, yCategories } = useBubbleDataGeneric(bubbleItems);
 
   let content;
   
@@ -38,10 +43,6 @@ export default function IncludedStudiesRenderer({ filteredStudies, type, chartId
       </Box>
     );
   } else if (isBubble) {
-    const items: BubbleItem[] = includedStudies.flatMap(study => 
-      study.searchSources.map(src => ({ x: Number(study.year), group: src, y: 1 }))
-    );
-    const { series, yCategories } = useBubbleDataGeneric(items);
     content = (
       <BubbleChart
         title="Search Sources Evolution"

--- a/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/SearchSourcesRenderer/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/subcomponents/ChartRenderer/SearchSourcesRenderer/index.tsx
@@ -27,6 +27,7 @@ export default function SearchSourcesRenderer({
   columnsVisible,
 }: Props) {
   const { t } = useTranslation("review/summarization-graphics");
+
   const sourceCountMap = filteredStudies.reduce<Record<string, number>>(
     (acc, study) => {
       study.searchSources.forEach((src) => {
@@ -40,10 +41,19 @@ export default function SearchSourcesRenderer({
   const labels = Object.keys(sourceCountMap);
   const data = Object.values(sourceCountMap);
 
-  let content;
-
   const isTable = type === "Table" || type === "Tabela";
   const isBubble = type === t("selectMenu.graphicsTypes.bubbleChart");
+  
+  const bubbleItems: BubbleItem[] = filteredStudies.flatMap((study) =>
+    study.searchSources.map((src) => ({
+      x: Number(study.year),
+      group: src,
+      y: 1,
+    }))
+  );
+  const { series, yCategories } = useBubbleDataGeneric(bubbleItems);
+
+  let content;
 
   if (type === t("selectMenu.graphicsTypes.pieChart")) {
     content = <PieChart title={t("sectionMenu.sections.searchSources")} labels={labels} data={data} />;
@@ -56,16 +66,7 @@ export default function SearchSourcesRenderer({
         section="searchSource"
       />
     );
-  } else if (type === t("selectMenu.graphicsTypes.bubbleChart")) {
-    const items: BubbleItem[] = filteredStudies.flatMap((study) =>
-      study.searchSources.map((src) => ({
-        x: Number(study.year),
-        group: src,
-        y: 1,
-      }))
-    );
-
-    const { series, yCategories } = useBubbleDataGeneric(items);
+  } else if (isBubble) {
     content = (
       <BubbleChart
         title={t("searchSourcesEvolution")}

--- a/src/features/review/summarization-graphics/pages/Graphics/subcomponents/QuestionsCharts/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/subcomponents/QuestionsCharts/index.tsx
@@ -118,6 +118,18 @@ function buildPickManyBubbleItems(
   });
 }
 
+function QuestionBubbleChart({ items }: { items: BubbleItem[] }) {
+  const { series, yCategories } = useBubbleDataGeneric(items);
+  return (
+    <BubbleChart
+      title=""
+      series={series}
+      yCategories={yCategories}
+      yaxisText=""
+    />
+  );
+}
+
 export const QuestionsCharts = ({
   selectedQuestionId,
   filteredStudies,
@@ -207,15 +219,7 @@ export const QuestionsCharts = ({
             });
           }
 
-          const { series, yCategories } = useBubbleDataGeneric(items);
-          chartContent = (
-            <BubbleChart
-              title=""
-              series={series}
-              yCategories={yCategories}
-              yaxisText=""
-            />
-          );
+          chartContent = <QuestionBubbleChart items={items} />;
 
         } else if (
           (type === "Item Table" || type === "Tabela por Item") &&


### PR DESCRIPTION
## Fix

This pull request fixes the chart rendering error.

Basically, the error was a violation of React's hook rules. The `useBubbleDataGeneric` and the `IncludedStudiesRenderer` hook was being called inside an `if else` statement.

React requires that hooks are always called in the same order. When switching from a bubble chart to a table, the hook disappeared from the flow and broke the screen.

A separate component was created for the `QuestionBubbleChart` that receives the items as props at the top of its own interface.

