### PR TITLE
feat(identification): remove bulk delete and add conditional session deletion modal

### DIFF
--- a/src/features/review/execution-identification/pages/Identification/subcomponents/cards/DatabaseCard/index.tsx
+++ b/src/features/review/execution-identification/pages/Identification/subcomponents/cards/DatabaseCard/index.tsx
@@ -23,14 +23,24 @@ import { AddIcon } from "@chakra-ui/icons";
 import { AiOutlineDelete, AiOutlineEdit, AiOutlineEye } from "react-icons/ai";
 import { useTranslation } from "react-i18next";
 
-import DeleteDatabaseModal from "../../modals/DeleteDatabase";
 import IdentificationModal from "../../modals/IdentificationModal";
+import DeleteSessionModal from "../../modals/DeleteSessionModal";
 
 import useGetSession from "../../../../../services/useGetSession";
-import UseDeleteSession from "../../../../../services/useDeleteSession";
 
 interface DatabaseCardProps {
   text: string;
+}
+
+interface Session {
+  id: string;
+  systematicStudyd: string;
+  userId: string;
+  searchString: string;
+  additionalInfo: string;
+  timestamp: string;
+  source: string;
+  numberOfRelatedStudies: number;
 }
 
 export default function DataBaseCard({ text }: DatabaseCardProps) {
@@ -41,8 +51,8 @@ export default function DataBaseCard({ text }: DatabaseCardProps) {
   const [actionModal, setActionModal] = useState<"create" | "update">("create");
   const [sessionId, setSessionId] = useState("");
 
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [deleteModal, setdeleteModal] = useState<"delete" | "refuse">("delete");
+  const [showDeleteSessionModal, setShowDeleteSessionModal] = useState(false);
+  const [sessionToDelete, setSessionToDelete] = useState<Session | null>(null);
 
   const { data, mutate } = useGetSession(text);
 
@@ -59,17 +69,9 @@ export default function DataBaseCard({ text }: DatabaseCardProps) {
     setShowModal(true);
   };
 
-  const handleDeleteSession = (id: string) => {
-    UseDeleteSession({ sessionId: id, mutate });
-  };
-
-  const handleOpenDeleteModal = (
-    action: "delete" | "refuse",
-    e: React.MouseEvent,
-  ) => {
-    e.stopPropagation();
-    setdeleteModal(action);
-    setShowDeleteModal(true);
+  const handleOpenDeleteSessionModal = (session: Session) => {
+    setSessionToDelete(session);
+    setShowDeleteSessionModal(true);
   };
 
   const handleNavigateToSession = (id: string, totalItems: number) => {
@@ -94,17 +96,15 @@ export default function DataBaseCard({ text }: DatabaseCardProps) {
             flexDirection="column"
             _hover={{ bg: "transparent" }}
           >
-            
             <Flex
               w="100%"
-              minH="10px" 
+              minH="10px"
               bg="#263C56"
               justifyContent="space-between"
               alignItems="center"
-              p="1.5rem 1.5rem" 
+              p="1.5rem 1.5rem"
             >
               <Flex flex="1" alignItems="center" gap="0.75rem">
-                
                 <Text
                   fontSize="lg"
                   fontWeight="bold"
@@ -129,23 +129,6 @@ export default function DataBaseCard({ text }: DatabaseCardProps) {
                 >
                   {t("dataBaseCard.addSession")}
                 </Button>
-
-                <IconButton
-                  aria-label="Delete Database"
-                  size="sm"
-                  icon={<AiOutlineDelete size={18} />}
-                  bg="white"
-                  color="red.600"
-                  borderRadius="md"
-                  transition="all 0.2s ease"
-                  _hover={{
-                    bg: "red.100",
-                    color: "red.700",
-                    transform: "translateY(-1px)",
-                  }}
-                  _active={{ transform: "translateY(0)" }}
-                  onClick={(e) => handleOpenDeleteModal("delete", e)}
-                />
               </Flex>
             </Flex>
 
@@ -195,16 +178,14 @@ export default function DataBaseCard({ text }: DatabaseCardProps) {
                 </Thead>
                 <Tbody>
                   {data && data.length > 0 ? (
-                    data.map((session: any, index: number) => (
+                    data.map((session: Session, index: number) => (
                       <Tr
                         key={session.id || index}
                         bg="white"
                         _even={{ bg: "#E2E8F0" }}
                       >
                         <Td color="gray.700">
-                          {new Date(session.timestamp).toLocaleDateString(
-                            "pt-BR",
-                          )}
+                          {new Date(session.timestamp).toLocaleDateString("pt-BR")}
                         </Td>
                         <Td color="gray.700">
                           {session.numberOfRelatedStudies}
@@ -217,9 +198,9 @@ export default function DataBaseCard({ text }: DatabaseCardProps) {
                               size="sm"
                               bg="transparent"
                               color="gray.600"
-                              borderRadius="md" 
+                              borderRadius="md"
                               transition="all 0.2s"
-                              _hover={{ bg: "blue.100", color: "blue.700" }} 
+                              _hover={{ bg: "blue.100", color: "blue.700" }}
                               onClick={() =>
                                 handleNavigateToSession(
                                   session.id,
@@ -233,7 +214,7 @@ export default function DataBaseCard({ text }: DatabaseCardProps) {
                               size="sm"
                               bg="transparent"
                               color="gray.600"
-                              borderRadius="md" 
+                              borderRadius="md"
                               transition="all 0.2s"
                               _hover={{ bg: "gray.200", color: "#263C56" }}
                               onClick={() =>
@@ -246,10 +227,10 @@ export default function DataBaseCard({ text }: DatabaseCardProps) {
                               size="sm"
                               bg="transparent"
                               color="red.500"
-                              borderRadius="md" 
+                              borderRadius="md"
                               transition="all 0.2s"
-                              _hover={{ bg: "red.100", color: "red.700" }} 
-                              onClick={() => handleDeleteSession(session.id)}
+                              _hover={{ bg: "red.100", color: "red.700" }}
+                              onClick={() => handleOpenDeleteSessionModal(session)}
                             />
                           </Flex>
                         </Td>
@@ -274,13 +255,11 @@ export default function DataBaseCard({ text }: DatabaseCardProps) {
         </AccordionItem>
       </Accordion>
 
-      {showDeleteModal && (
-        <DeleteDatabaseModal
-          show={setShowDeleteModal}
-          action={deleteModal}
-          sessions={data}
+      {showDeleteSessionModal && sessionToDelete && (
+        <DeleteSessionModal
+          show={setShowDeleteSessionModal}
+          session={sessionToDelete}
           mutate={mutate}
-          databaseName={text}
         />
       )}
 

--- a/src/features/review/execution-identification/pages/Identification/subcomponents/modals/DeleteSessionModal/index.tsx
+++ b/src/features/review/execution-identification/pages/Identification/subcomponents/modals/DeleteSessionModal/index.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useState } from "react";
+import { Button, Divider, Flex, FormControl, FormLabel, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Text } from "@chakra-ui/react";
+import { IoIosWarning } from "react-icons/io";
+import { useDisclosure } from "@chakra-ui/react";
+import { KeyedMutator } from "swr";
+import { useTranslation } from "react-i18next";
+import useToaster from "@components/feedback/Toaster";
+
+import Axios from "../../../../../../../../infrastructure/http/axiosClient";
+import UseDeleteSession from "../../../../../services/useDeleteSession";
+
+interface Session {
+  id: string;
+  systematicStudyd: string;
+  userId: string;
+  searchString: string;
+  additionalInfo: string;
+  timestamp: string;
+  source: string;
+  numberOfRelatedStudies: number;
+}
+
+interface DeleteSessionModalProps {
+  show: (value: boolean) => void;
+  session: Session;
+  mutate: KeyedMutator<Session[]>;
+}
+
+type SelectionStatus = "INCLUDED" | "EXCLUDED" | "DUPLICATED" | "UNCLASSIFIED";
+
+async function canDeleteSession(
+  reviewId: string,
+  sessionId: string,
+  numberOfRelatedStudies: number
+): Promise<boolean> {
+  if (numberOfRelatedStudies === 0) return true;
+
+  const size = Math.max(numberOfRelatedStudies, 1);
+  const path = `systematic-study/${reviewId}/find-by-search-session/${sessionId}`;
+  const response = await Axios.get(path, { params: { page: 0, size } });
+  const studies = response.data?.studyReviews ?? [];
+
+  const blockedStatuses: SelectionStatus[] = ["INCLUDED", "EXCLUDED", "DUPLICATED"];
+
+  return !studies.some((s: any) =>
+    blockedStatuses.includes(s.selectionStatus as SelectionStatus)
+  );
+}
+
+export default function DeleteSessionModal({
+  show,
+  session,
+  mutate,
+}: DeleteSessionModalProps) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isChecking, setIsChecking] = useState(true);
+  const [canDelete, setCanDelete] = useState(false);
+  const toast = useToaster();
+  const { t } = useTranslation("review/execution-identification");
+  const reviewId = localStorage.getItem("systematicReviewId") ?? "";
+
+  useEffect(() => {
+    onOpen();
+    checkIfCanDelete();
+  }, []);
+
+  const checkIfCanDelete = async () => {
+    setIsChecking(true);
+    try {
+      const result = await canDeleteSession(
+        reviewId,
+        session.id,
+        session.numberOfRelatedStudies
+      );
+      setCanDelete(result);
+    } catch {
+      setCanDelete(false);
+    } finally {
+      setIsChecking(false);
+    }
+  };
+
+  const handleClose = () => {
+    show(false);
+    onClose();
+  };
+
+  const handleConfirmDelete = async () => {
+    setIsDeleting(true);
+    try {
+      await UseDeleteSession({ sessionId: session.id, mutate });
+      toast({
+        title: t("dataBaseCard.deleteSessionModal.toasts.success.title"),
+        description: t("dataBaseCard.deleteSessionModal.toasts.success.description"),
+        status: "success",
+      });
+      handleClose();
+    } catch {
+      toast({
+        title: t("dataBaseCard.deleteSessionModal.toasts.catch.title"),
+        description: t("dataBaseCard.deleteSessionModal.toasts.catch.description"),
+        status: "error",
+      });
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader color="#263C56">
+          <FormControl mt={3} display="flex" mb={4} gap={3} alignItems="center">
+            <Flex gap={3}>
+              <IoIosWarning size="2rem" />
+              <FormLabel fontWeight="bold" fontSize="larger">
+                {t("dataBaseCard.deleteSessionModal.heading")}
+              </FormLabel>
+            </Flex>
+          </FormControl>
+          <ModalCloseButton onClick={handleClose} />
+        </ModalHeader>
+
+        <ModalBody>
+          {isChecking ? (
+            <Text color="gray.500">
+              {t("dataBaseCard.deleteSessionModal.checking")}
+            </Text>
+          ) : canDelete ? (
+            <Text>
+              {t("dataBaseCard.deleteSessionModal.confirmMessage")}
+            </Text>
+          ) : (
+            <Flex direction="column" gap={2}>
+              <Text fontWeight="semibold" color="red.500">
+                {t("dataBaseCard.deleteSessionModal.blockedTitle")}
+              </Text>
+              <Text>
+                {t("dataBaseCard.deleteSessionModal.blockedMessage")}
+              </Text>
+            </Flex>
+          )}
+        </ModalBody>
+
+        <Divider />
+
+        <ModalFooter mt={3}>
+          <Flex gap={2} justifyContent="flex-end">
+            <Button
+              onClick={handleClose}
+              backgroundColor="#263C56"
+              color="#EBF0F3"
+              boxShadow="sm"
+              _hover={{ bg: "#2A4A6D", boxShadow: "md" }}
+              isDisabled={isDeleting}
+            >
+              {t("dataBaseCard.deleteSessionModal.cancel")}
+            </Button>
+
+            {canDelete && !isChecking && (
+              <Button
+                onClick={handleConfirmDelete}
+                backgroundColor="red.500"
+                color="white"
+                boxShadow="sm"
+                _hover={{ bg: "red.600", boxShadow: "md" }}
+                isDisabled={isDeleting}
+                isLoading={isDeleting}
+              >
+                {t("dataBaseCard.deleteSessionModal.confirm")}
+              </Button>
+            )}
+          </Flex>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/locales/en/review/execution-identification.json
+++ b/src/locales/en/review/execution-identification.json
@@ -31,6 +31,25 @@
             "cancel": "Cancel",
             "remove": "Remove"
         },
+        "deleteSessionModal": {
+            "heading": "Delete session",
+            "confirmMessage": "Are you sure you want to delete this session? This action is permanent and cannot be undone.",
+            "blockedTitle": "Session cannot be deleted",
+            "blockedMessage": "This session has Included, Excluded or Duplicated articles. Reset all articles to Unclassified before deleting the session.",
+            "checking": "Checking session articles...",
+            "cancel": "Cancel",
+            "confirm": "Confirm deletion",
+            "toasts": {
+                "success": {
+                    "title": "Session deleted successfully!",
+                    "description": "The session has been removed."
+                },
+                "catch": {
+                    "title": "Action Failed",
+                    "description": "Could not delete the session. Please try again."
+                }
+            }
+        },
         "accordionDashboard": {
             "date": "Date",
             "studies": "Studies",

--- a/src/locales/pt/review/execution-identification.json
+++ b/src/locales/pt/review/execution-identification.json
@@ -31,6 +31,25 @@
             "cancel": "Cancelar",
             "remove": "Remover"
         },
+        "deleteSessionModal": {
+            "heading": "Excluir sessão",
+            "confirmMessage": "Tem certeza de que deseja excluir esta sessão? Esta ação é permanente e não pode ser desfeita.",
+            "blockedTitle": "Sessão não pode ser excluída",
+            "blockedMessage": "Esta sessão possui artigos Incluídos, Excluídos ou Duplicados. Redefina todos os artigos para Não Classificado antes de excluir a sessão.",
+            "checking": "Verificando artigos da sessão...",
+            "cancel": "Cancelar",
+            "confirm": "Confirmar exclusão",
+            "toasts": {
+                "success": {
+                    "title": "Sessão excluída com sucesso!",
+                    "description": "A sessão foi removida."
+                },
+                "catch": {
+                    "title": "Ação Falhou",
+                    "description": "Não foi possível excluir a sessão. Tente novamente."
+                }
+            }
+        },
         "accordionDashboard": {
             "date": "Data",
             "studies": "Estudos",


### PR DESCRIPTION
### Este Pull Request remove a possibilidade de exclusão em massa da base de dados na tela de identificação e introduz um fluxo seguro e condicional para a exclusão de sessões individuais, garantindo a integridade dos dados.

## Alterações Realizadas
- DatabaseCard: Remoção do botão (IconButton) e da lógica do modal de exclusão completa do banco de dados no header. O botão de exclusão individual agora abre o novo DeleteSessionModal.
- DeleteSessionModal: Criação do novo componente que consome os artigos da sessão (GET /find-by-search-session).
- Bloqueio: Se houver algum estudo com status INCLUDED, EXCLUDED ou DUPLICATED, exibe uma mensagem de alerta e impede a ação.
- Confirmação: Se todos os estudos estiverem como UNCLASSIFIED, libera o botão para confirmar a exclusão.
- i18n: Inclusão das chaves e textos de tradução para o novo modal em ambos os idiomas suportados.