### PR TITLE
fix: refresh articles after marking duplicated studies

### DIFF
--- a/src/features/review/execution-extraction/pages/Extraction/index.tsx
+++ b/src/features/review/execution-extraction/pages/Extraction/index.tsx
@@ -139,6 +139,7 @@ export default function Extraction() {
               <ButtonsForMultipleSelection
                 onShowSelectedArticles={setShowSelected}
                 isShown={showSelected}
+                reloadArticles={mutate}
               />
             ) : null}
           </Flex>

--- a/src/features/review/execution-selection/pages/Selection/index.tsx
+++ b/src/features/review/execution-selection/pages/Selection/index.tsx
@@ -143,6 +143,7 @@ export default function Selection() {
               <ButtonsForMultipleSelection
                 onShowSelectedArticles={setShowSelected}
                 isShown={showSelected}
+                reloadArticles={mutate}
               />
             ) : null}
           </Flex>

--- a/src/features/review/shared/components/common/buttons/ButtonsForMultipleSelection/index.tsx
+++ b/src/features/review/shared/components/common/buttons/ButtonsForMultipleSelection/index.tsx
@@ -24,11 +24,13 @@ const buttonSX = {
 interface ButtonsForMultipleSelectionProps {
   onShowSelectedArticles: (showSelected: boolean) => void;
   isShown: boolean;
+  reloadArticles: () => Promise<any>;
 }
 
 export default function ButtonsForMultipleSelection({
   onShowSelectedArticles,
   isShown,
+  reloadArticles,
 }: ButtonsForMultipleSelectionProps) {
   const window = useWindowWidth();
   const studyContext = useContext(StudyContext);
@@ -45,8 +47,10 @@ export default function ButtonsForMultipleSelection({
 
   const articles = studyContext?.selectedArticles;
 
-  const handleSendDuplicatedStudies = () => {
-    sendDuplicatedStudies();
+  const handleSendDuplicatedStudies = async () => {
+    await sendDuplicatedStudies();
+    await reloadArticles();
+
     studyContext?.clearSelectedArticles();
     onShowSelectedArticles(false);
   };

--- a/src/features/review/shared/services/useSendDuplicatedStudies.tsx
+++ b/src/features/review/shared/services/useSendDuplicatedStudies.tsx
@@ -11,10 +11,12 @@ export default function useSendDuplicatedStudies({
 }: SendDuplicatedStudiesProps) {
   const studyReviewId = localStorage.getItem("systematicReviewId");
 
-  const sendDuplicatedStudies = () => {
+  const sendDuplicatedStudies = async () => {
     if (firstSelected === null) return;
     const path = `systematic-study/${studyReviewId}/study-review/${firstSelected}/duplicated`;
-    Axios.patch(path, { duplicatedStudyIds: duplicatedStudies });
+    await Axios.patch(path, {
+      duplicatedStudyIds: duplicatedStudies,
+    });
   };
 
   return {


### PR DESCRIPTION
# Summary

This PR fixes the issue where articles marked as duplicated were not immediately reflected in the UI. Previously, after marking studies as duplicated, users had to manually refresh the page to see the updated state.

The solution revalidates the articles list after the duplication request completes, ensuring the interface is updated automatically.

## Changes

- Made `sendDuplicatedStudies` asynchronous and awaited the `PATCH` request.
- Added a `reloadArticles` prop to `ButtonsForMultipleSelection`.
- Triggered `reloadArticles()` after successfully marking studies as duplicated.
- Passed the SWR `mutate` function from both **Selection** and **Extraction** pages to `ButtonsForMultipleSelection`.

## Impact

- Improves the user experience by keeping the UI synchronized with the backend after marking duplicated studies.
- Removes the need for a manual page refresh to visualize the updated state.