### PR TITLE
fix: validate that all study sources are unclassified before allowing deletion

### DIFF
--- a/src/features/review/execution-identification/pages/Identification/subcomponents/modals/DeleteSessionModal/index.tsx
+++ b/src/features/review/execution-identification/pages/Identification/subcomponents/modals/DeleteSessionModal/index.tsx
@@ -1,13 +1,9 @@
-import { useEffect, useState } from "react";
-import { Button, Divider, Flex, FormControl, FormLabel, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Text } from "@chakra-ui/react";
-import { IoIosWarning } from "react-icons/io";
-import { useDisclosure } from "@chakra-ui/react";
 import { KeyedMutator } from "swr";
 import { useTranslation } from "react-i18next";
-import useToaster from "@components/feedback/Toaster";
 
 import Axios from "../../../../../../../../infrastructure/http/axiosClient";
 import UseDeleteSession from "../../../../../services/useDeleteSession";
+import DeleteWithValidationModal from "@features/review/shared/components/common/modals/DeleteWithValidationModal";
 
 interface Session {
   id: string;
@@ -41,7 +37,6 @@ async function canDeleteSession(
   const studies = response.data?.studyReviews ?? [];
 
   const blockedStatuses: SelectionStatus[] = ["INCLUDED", "EXCLUDED", "DUPLICATED"];
-
   return !studies.some((s: any) =>
     blockedStatuses.includes(s.selectionStatus as SelectionStatus)
   );
@@ -52,129 +47,31 @@ export default function DeleteSessionModal({
   session,
   mutate,
 }: DeleteSessionModalProps) {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [isChecking, setIsChecking] = useState(true);
-  const [canDelete, setCanDelete] = useState(false);
-  const toast = useToaster();
   const { t } = useTranslation("review/execution-identification");
   const reviewId = localStorage.getItem("systematicReviewId") ?? "";
 
-  useEffect(() => {
-    onOpen();
-    checkIfCanDelete();
-  }, []);
-
-  const checkIfCanDelete = async () => {
-    setIsChecking(true);
-    try {
-      const result = await canDeleteSession(
-        reviewId,
-        session.id,
-        session.numberOfRelatedStudies
-      );
-      setCanDelete(result);
-    } catch {
-      setCanDelete(false);
-    } finally {
-      setIsChecking(false);
-    }
-  };
-
-  const handleClose = () => {
-    show(false);
-    onClose();
-  };
-
-  const handleConfirmDelete = async () => {
-    setIsDeleting(true);
-    try {
-      await UseDeleteSession({ sessionId: session.id, mutate });
-      toast({
-        title: t("dataBaseCard.deleteSessionModal.toasts.success.title"),
-        description: t("dataBaseCard.deleteSessionModal.toasts.success.description"),
-        status: "success",
-      });
-      handleClose();
-    } catch {
-      toast({
-        title: t("dataBaseCard.deleteSessionModal.toasts.catch.title"),
-        description: t("dataBaseCard.deleteSessionModal.toasts.catch.description"),
-        status: "error",
-      });
-    } finally {
-      setIsDeleting(false);
-    }
-  };
-
   return (
-    <Modal isOpen={isOpen} onClose={handleClose}>
-      <ModalOverlay />
-      <ModalContent>
-        <ModalHeader color="#263C56">
-          <FormControl mt={3} display="flex" mb={4} gap={3} alignItems="center">
-            <Flex gap={3}>
-              <IoIosWarning size="2rem" />
-              <FormLabel fontWeight="bold" fontSize="larger">
-                {t("dataBaseCard.deleteSessionModal.heading")}
-              </FormLabel>
-            </Flex>
-          </FormControl>
-          <ModalCloseButton onClick={handleClose} />
-        </ModalHeader>
-
-        <ModalBody>
-          {isChecking ? (
-            <Text color="gray.500">
-              {t("dataBaseCard.deleteSessionModal.checking")}
-            </Text>
-          ) : canDelete ? (
-            <Text>
-              {t("dataBaseCard.deleteSessionModal.confirmMessage")}
-            </Text>
-          ) : (
-            <Flex direction="column" gap={2}>
-              <Text fontWeight="semibold" color="red.500">
-                {t("dataBaseCard.deleteSessionModal.blockedTitle")}
-              </Text>
-              <Text>
-                {t("dataBaseCard.deleteSessionModal.blockedMessage")}
-              </Text>
-            </Flex>
-          )}
-        </ModalBody>
-
-        <Divider />
-
-        <ModalFooter mt={3}>
-          <Flex gap={2} justifyContent="flex-end">
-            <Button
-              onClick={handleClose}
-              backgroundColor="#263C56"
-              color="#EBF0F3"
-              boxShadow="sm"
-              _hover={{ bg: "#2A4A6D", boxShadow: "md" }}
-              isDisabled={isDeleting}
-            >
-              {t("dataBaseCard.deleteSessionModal.cancel")}
-            </Button>
-
-            {canDelete && !isChecking && (
-              <Button
-                onClick={handleConfirmDelete}
-                backgroundColor="red.500"
-                color="white"
-                boxShadow="sm"
-                _hover={{ bg: "red.600", boxShadow: "md" }}
-                isDisabled={isDeleting}
-                isLoading={isDeleting}
-              >
-                {t("dataBaseCard.deleteSessionModal.confirm")}
-              </Button>
-            )}
-          </Flex>
-        </ModalFooter>
-      </ModalContent>
-    </Modal>
+    <DeleteWithValidationModal
+      checkCanDelete={() =>
+        canDeleteSession(reviewId, session.id, session.numberOfRelatedStudies)
+      }
+      onConfirm={async () => {
+        await UseDeleteSession({ sessionId: session.id, mutate });
+      }}
+      onClose={() => show(false)}
+      labels={{
+        heading: t("dataBaseCard.deleteSessionModal.heading"),
+        confirmMessage: t("dataBaseCard.deleteSessionModal.confirmMessage"),
+        blockedTitle: t("dataBaseCard.deleteSessionModal.blockedTitle"),
+        blockedMessage: t("dataBaseCard.deleteSessionModal.blockedMessage"),
+        checking: t("dataBaseCard.deleteSessionModal.checking"),
+        cancel: t("dataBaseCard.deleteSessionModal.cancel"),
+        confirm: t("dataBaseCard.deleteSessionModal.confirm"),
+        successTitle: t("dataBaseCard.deleteSessionModal.toasts.success.title"),
+        successDescription: t("dataBaseCard.deleteSessionModal.toasts.success.description"),
+        errorTitle: t("dataBaseCard.deleteSessionModal.toasts.catch.title"),
+        errorDescription: t("dataBaseCard.deleteSessionModal.toasts.catch.description"),
+      }}
+    />
   );
 }

--- a/src/features/review/planning-protocol/components/common/modals/DeleteSourceModal/index.tsx
+++ b/src/features/review/planning-protocol/components/common/modals/DeleteSourceModal/index.tsx
@@ -1,0 +1,58 @@
+import { useTranslation } from "react-i18next";
+
+import Axios from "../../../../../../../infrastructure/http/axiosClient";
+import DeleteWithValidationModal from "@features/review/shared/components/common/modals/DeleteWithValidationModal";
+
+interface DeleteSourceModalProps {
+  sourceName: string;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+type SelectionStatus = "INCLUDED" | "EXCLUDED" | "DUPLICATED" | "UNCLASSIFIED";
+
+async function canDeleteSource(
+  reviewId: string,
+  sourceName: string
+): Promise<boolean> {
+  const path = `systematic-study/${reviewId}/search-source/${encodeURIComponent(sourceName)}`;
+  const response = await Axios.get(path);
+  const studies = response.data?.studyReviews ?? [];
+
+  if (studies.length === 0) return true;
+
+  const blockedStatuses: SelectionStatus[] = ["INCLUDED", "EXCLUDED", "DUPLICATED"];
+  return !studies.some((s: any) =>
+    blockedStatuses.includes(s.selectionStatus as SelectionStatus)
+  );
+}
+
+export default function DeleteSourceModal({
+  sourceName,
+  onConfirm,
+  onClose,
+}: DeleteSourceModalProps) {
+  const { t } = useTranslation("review/planning-protocol");
+  const reviewId = localStorage.getItem("systematicReviewId") ?? "";
+
+  return (
+    <DeleteWithValidationModal
+      checkCanDelete={() => canDeleteSource(reviewId, sourceName)}
+      onConfirm={async () => onConfirm()}
+      onClose={onClose}
+      labels={{
+        heading: t("deleteSourceModal.heading"),
+        confirmMessage: `${t("deleteSourceModal.confirmMessage")} ${sourceName}?`,
+        blockedTitle: t("deleteSourceModal.blockedTitle"),
+        blockedMessage: t("deleteSourceModal.blockedMessage"),
+        checking: t("deleteSourceModal.checking"),
+        cancel: t("deleteSourceModal.cancel"),
+        confirm: t("deleteSourceModal.confirm"),
+        successTitle: t("deleteSourceModal.toasts.success.title"),
+        successDescription: t("deleteSourceModal.toasts.success.description"),
+        errorTitle: t("deleteSourceModal.toasts.catch.title"),
+        errorDescription: t("deleteSourceModal.toasts.catch.description"),
+      }}
+    />
+  );
+}

--- a/src/features/review/planning-protocol/components/common/tables/SelectInfosTable/index.tsx
+++ b/src/features/review/planning-protocol/components/common/tables/SelectInfosTable/index.tsx
@@ -1,6 +1,8 @@
-import {Table, Tbody, Tr, Td, TableContainer} from "@chakra-ui/react";
+import { useState } from "react";
+import { Table, Tbody, Tr, Td, TableContainer } from "@chakra-ui/react";
 import DeleteButton from "@components/common/buttons/DeleteButton";
-import { tbConteiner } from "./styles.ts"
+import DeleteSourceModal from "@features/review/planning-protocol/components/common/modals/DeleteSourceModal";
+import { tbConteiner } from "./styles.ts";
 
 interface SelectInfosTableProps {
   selectedItems: string[];
@@ -11,33 +13,52 @@ export default function SelectInfosTable({
   selectedItems,
   onDeleteItem,
 }: SelectInfosTableProps) {
+  const [pendingDeleteIndex, setPendingDeleteIndex] = useState<number | null>(null);
+
+  const handleDeleteClick = (index: number) => {
+    setPendingDeleteIndex(index);
+  };
+
+  const handleConfirmDelete = () => {
+    if (pendingDeleteIndex !== null) {
+      onDeleteItem(pendingDeleteIndex);
+      setPendingDeleteIndex(null);
+    }
+  };
+
+  const handleCloseModal = () => {
+    setPendingDeleteIndex(null);
+  };
+
   return (
-    <TableContainer 
-      w="100%" 
-      sx={{ 
-        ...tbConteiner, 
-        width: "100% !important", 
-        maxWidth: "100% !important" 
-      }}
-    >
-      
-      <Table variant="simple" size="md" w="100%">
-        <Tbody className="tableBody">
-          {selectedItems.map((item, index) => (
-            <Tr key={index}>
-              <Td whiteSpace={"normal"} wordBreak={"break-word"} py={"1"}>
-                {item}
-              </Td>
-              <Td textAlign={"right"} py={"1"}>
-                <DeleteButton
-                  index={index}
-                  handleDelete={() => onDeleteItem(index)}
-                />
-              </Td>
-            </Tr>
-          ))}
-        </Tbody>
-      </Table>
-    </TableContainer>
+    <>
+      <TableContainer sx={tbConteiner}>
+        <Table variant="simple" size="md">
+          <Tbody className="tableBody">
+            {selectedItems.map((item, index) => (
+              <Tr key={index}>
+                <Td whiteSpace={"normal"} wordBreak={"break-word"} py={"1"}>
+                  {item}
+                </Td>
+                <Td textAlign={"right"} py={"1"}>
+                  <DeleteButton
+                    index={index}
+                    handleDelete={() => handleDeleteClick(index)}
+                  />
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </TableContainer>
+
+      {pendingDeleteIndex !== null && (
+        <DeleteSourceModal
+          sourceName={selectedItems[pendingDeleteIndex]}
+          onConfirm={handleConfirmDelete}
+          onClose={handleCloseModal}
+        />
+      )}
+    </>
   );
 }

--- a/src/features/review/planning-protocol/services/useCreateProtocol.tsx
+++ b/src/features/review/planning-protocol/services/useCreateProtocol.tsx
@@ -261,11 +261,13 @@ export default function useCreateProtocol() {
   async function sendSelectData(data: string[], context: string) {
     let content;
 
-    const upperData = data.map((i) => i.toUpperCase());
-
     try {
-      if (context == "Languages") content = { studiesLanguages: upperData };
-      else content = { informationSources: upperData };
+      if (context == "Languages") {
+        const upperData = data.map((i) => i.toUpperCase());
+        content = { studiesLanguages: upperData };
+      } else {
+        content = { informationSources: data };
+      }
 
       await Axios.put(url, content);
     } catch (err) {

--- a/src/features/review/shared/components/common/modals/DeleteWithValidationModal/index.tsx
+++ b/src/features/review/shared/components/common/modals/DeleteWithValidationModal/index.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from "react";
+import { Button, Divider, Flex, FormControl, FormLabel, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Text } from "@chakra-ui/react";
+import { IoIosWarning } from "react-icons/io";
+import { useDisclosure } from "@chakra-ui/react";
+import useToaster from "@components/feedback/Toaster";
+
+interface Labels {
+  heading: string;
+  confirmMessage: string;
+  blockedTitle: string;
+  blockedMessage: string;
+  checking: string;
+  cancel: string;
+  confirm: string;
+  successTitle: string;
+  successDescription: string;
+  errorTitle: string;
+  errorDescription: string;
+}
+
+interface DeleteWithValidationModalProps {
+  checkCanDelete: () => Promise<boolean>;
+  onConfirm: () => Promise<void>;
+  onClose: () => void;
+  labels: Labels;
+}
+
+export default function DeleteWithValidationModal({
+  checkCanDelete,
+  onConfirm,
+  onClose: onCloseProp,
+  labels,
+}: DeleteWithValidationModalProps) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [isChecking, setIsChecking] = useState(true);
+  const [canDelete, setCanDelete] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const toast = useToaster();
+
+  useEffect(() => {
+    onOpen();
+    runCheck();
+  }, []);
+
+  const runCheck = async () => {
+    setIsChecking(true);
+    try {
+      const result = await checkCanDelete();
+      setCanDelete(result);
+    } catch {
+      setCanDelete(false);
+    } finally {
+      setIsChecking(false);
+    }
+  };
+
+  const handleClose = () => {
+    onCloseProp();
+    onClose();
+  };
+
+  const handleConfirm = async () => {
+    setIsDeleting(true);
+    try {
+      await onConfirm();
+      toast({
+        title: labels.successTitle,
+        description: labels.successDescription,
+        status: "success",
+      });
+      handleClose();
+    } catch {
+      toast({
+        title: labels.errorTitle,
+        description: labels.errorDescription,
+        status: "error",
+      });
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader color="#263C56">
+          <FormControl mt={3} display="flex" mb={4} gap={3} alignItems="center">
+            <Flex gap={3}>
+              <IoIosWarning size="2rem" />
+              <FormLabel fontWeight="bold" fontSize="larger">
+                {labels.heading}
+              </FormLabel>
+            </Flex>
+          </FormControl>
+          <ModalCloseButton onClick={handleClose} />
+        </ModalHeader>
+
+        <ModalBody>
+          {isChecking ? (
+            <Text color="gray.500">{labels.checking}</Text>
+          ) : canDelete ? (
+            <Text>{labels.confirmMessage}</Text>
+          ) : (
+            <Flex direction="column" gap={2}>
+              <Text fontWeight="semibold" color="red.500">
+                {labels.blockedTitle}
+              </Text>
+              <Text>{labels.blockedMessage}</Text>
+            </Flex>
+          )}
+        </ModalBody>
+
+        <Divider />
+
+        <ModalFooter mt={3}>
+          <Flex gap={2} justifyContent="flex-end">
+            <Button
+              onClick={handleClose}
+              backgroundColor="#263C56"
+              color="#EBF0F3"
+              boxShadow="sm"
+              _hover={{ bg: "#2A4A6D", boxShadow: "md" }}
+              isDisabled={isDeleting}
+            >
+              {labels.cancel}
+            </Button>
+
+            {canDelete && !isChecking && (
+              <Button
+                onClick={handleConfirm}
+                backgroundColor="red.500"
+                color="white"
+                boxShadow="sm"
+                _hover={{ bg: "red.600", boxShadow: "md" }}
+                isDisabled={isDeleting}
+                isLoading={isDeleting}
+              >
+                {labels.confirm}
+              </Button>
+            )}
+          </Flex>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/locales/en/review/planning-protocol.json
+++ b/src/locales/en/review/planning-protocol.json
@@ -25,7 +25,7 @@
                 "status": {
                     "pending": "Pending",
                     "expired": "Expired",
-                    "excluding": "Excluding"               
+                    "excluding": "Excluding"
                 },
                 "role": {
                     "role": "Role",
@@ -178,7 +178,7 @@
                 "questionType": {
                     "textual": "textual",
                     "pickList": "pick list",
-                    "numberedScale": "number scale", 
+                    "numberedScale": "number scale",
                     "labeledList": "labeled list",
                     "pickMany": "pick many"
                 },
@@ -229,5 +229,24 @@
     "toasts": {
         "duplicateTitle": "Duplicate Entry",
         "duplicateDescription": "This item already exists!"
+    },
+    "deleteSourceModal": {
+        "heading": "Delete source",
+        "confirmMessage": "Are you sure you want to delete the source",
+        "blockedTitle": "Source cannot be deleted",
+        "blockedMessage": "This source has Included, Excluded or Duplicated articles. Reset all articles to Unclassified before deleting the source.",
+        "checking": "Checking source articles...",
+        "cancel": "Cancel",
+        "confirm": "Confirm deletion",
+        "toasts": {
+            "success": {
+                "title": "Source deleted successfully!",
+                "description": "The source has been removed."
+            },
+            "catch": {
+                "title": "Action Failed",
+                "description": "Could not delete the source. Please try again."
+            }
+        }
     }
 }

--- a/src/locales/pt/review/planning-protocol.json
+++ b/src/locales/pt/review/planning-protocol.json
@@ -229,5 +229,24 @@
     "toasts": {
         "duplicateTitle": "Palavra-chave Duplicada",
         "duplicateDescription": "Esta palavra-chave já existe!"
+    },
+    "deleteSourceModal": {
+        "heading": "Excluir fonte",
+        "confirmMessage": "Tem certeza de que deseja excluir a fonte",
+        "blockedTitle": "Fonte não pode ser excluída",
+        "blockedMessage": "Esta fonte possui artigos Incluídos, Excluídos ou Duplicados. Redefina todos os artigos para Não Classificado antes de excluir a fonte.",
+        "checking": "Verificando artigos da fonte...",
+        "cancel": "Cancelar",
+        "confirm": "Confirmar exclusão",
+        "toasts": {
+            "success": {
+                "title": "Fonte excluída com sucesso!",
+                "description": "A fonte foi removida."
+            },
+            "catch": {
+                "title": "Ação Falhou",
+                "description": "Não foi possível excluir a fonte. Tente novamente."
+            }
+        }
     }
 }


### PR DESCRIPTION
## Descrição:
### Padronizar a exclusão de source em Sources com a de sessão em Identification — validar se todos os estudos estão UNCLASSIFIED antes de permitir a exclusão
- Bug encontrado na implementação: ao excluir uma source, artigos de todas as outras bases também sumiam de Identification (não só os da source excluída)
- Causa: sendSelectData aplicava .toUpperCase() em informationSources, quebrando o match (case-sensitive) com o source salvo em cada study-review
- Correção: .toUpperCase() restrito ao contexto "Languages"; informationSources agora mantém a capitalização original