### PR TITLE
GM-fix-responsiveness

### DIFF
--- a/src/components/common/inputs/InputText/index.tsx
+++ b/src/components/common/inputs/InputText/index.tsx
@@ -51,12 +51,12 @@ export default function InputText({
           type={type}
           name={nome}
           placeholder={placeholder}
-          w={isSearchField ? "250px" : "100%"}
+          w={isSearchField ? "205px" : "100%"}
           bgColor={"#ffffff"}
           borderRadius={"3px"}
           border="2px solid"
           borderColor="gray.300"
-          fontSize={"lg"}
+          fontSize={isSearchField ? "medium" : "lg"}
           _placeholder={{ opacity: 1, color: "gray.500" }}
           focusBorderColor="#2E4B6C"
           onChange={onChange}

--- a/src/components/common/inputs/InputText/index.tsx
+++ b/src/components/common/inputs/InputText/index.tsx
@@ -1,6 +1,8 @@
 // External library
 import { FormControl, FormLabel, Input } from "@chakra-ui/react";
 
+import useWindowWidth from "@features/shared/hooks/useWindowWidth";
+
 // Types
 interface ITextFieldProps {
   label?: string;
@@ -35,6 +37,7 @@ export default function InputText({
   isDisabled,
 }: ITextFieldProps) {
   const isSearchField = type === "search";
+  const window = useWindowWidth();
 
   return (
     <FormControl
@@ -51,7 +54,7 @@ export default function InputText({
           type={type}
           name={nome}
           placeholder={placeholder}
-          w={isSearchField ? "205px" : "100%"}
+          w={isSearchField ? window < 1000 ? "225px" : "250px" : "100%"}
           bgColor={"#ffffff"}
           borderRadius={"3px"}
           border="2px solid"

--- a/src/features/review/execution-extraction/pages/Extraction/index.tsx
+++ b/src/features/review/execution-extraction/pages/Extraction/index.tsx
@@ -39,6 +39,7 @@ export default function Extraction() {
   useEffect(() => {
     if(window < 1000 && sidebarState === "open") setSidebarState("collapsed");
   }, []);
+  const [isMutipleSelectionEnable, setIsMultipleSelectionEnable] = useState<boolean>(false);
   const [searchString, setSearchString] = useState<string>("");
   const [showSelected, setShowSelected] = useState<boolean>(false);
   const [fetchedTotalPages, setFetchedTotalPages] = useState<number>(1);
@@ -125,8 +126,8 @@ export default function Extraction() {
           />
         </Flex>
         <Box sx={inputconteiner}>
-          <Flex gap="1rem" w="1rem" justifyContent="space-between">
-            {window > 1000 && (
+          <Box>
+            {!isMutipleSelectionEnable && (
               <InputText
                 type="search"
                 placeholder={t("search")}
@@ -140,9 +141,10 @@ export default function Extraction() {
                 onShowSelectedArticles={setShowSelected}
                 isShown={showSelected}
                 reloadArticles={mutate}
+                setIsMultipleSelectionEnable={setIsMultipleSelectionEnable}
               />
             ) : null}
-          </Flex>
+          </Box>
           <Box
             display="flex"
             gap="1rem"

--- a/src/features/review/execution-selection/pages/Selection/index.tsx
+++ b/src/features/review/execution-selection/pages/Selection/index.tsx
@@ -38,6 +38,7 @@ export default function Selection() {
   useEffect(() => {
     if(window < 1000 && sidebarState === "open") setSidebarState("collapsed");
   }, []);
+  const [isMutipleSelectionEnable, setIsMultipleSelectionEnable] = useState<boolean>(false);
   const [searchString, setSearchString] = useState<string>("");
   const [showSelected, setShowSelected] = useState<boolean>(false);
   const [fetchedTotalPages, setFetchedTotalPages] = useState<number>(1);
@@ -129,8 +130,8 @@ export default function Selection() {
           />
         </Flex>
         <Box sx={inputconteiner}>
-          <Flex gap="1rem" w="1rem" justifyContent="space-between">
-            {window > 1000 && (
+          <Box>
+            {!isMutipleSelectionEnable && (
               <InputText
                 type="search"
                 placeholder={t("search")}
@@ -144,9 +145,10 @@ export default function Selection() {
                 onShowSelectedArticles={setShowSelected}
                 isShown={showSelected}
                 reloadArticles={mutate}
+                setIsMultipleSelectionEnable={setIsMultipleSelectionEnable}
               />
             ) : null}
-          </Flex>
+          </Box>
           <Box
             display="flex"
             gap="1rem"

--- a/src/features/review/planning-protocol/components/common/tables/SelectInfosTable/index.tsx
+++ b/src/features/review/planning-protocol/components/common/tables/SelectInfosTable/index.tsx
@@ -32,7 +32,14 @@ export default function SelectInfosTable({
 
   return (
     <>
-      <TableContainer sx={tbConteiner}>
+      <TableContainer
+        w="100%"
+        sx={{
+          ...tbConteiner,
+          width: "100% !important",
+          maxWidth: "100% !important"
+        }}
+      >
         <Table variant="simple" size="md">
           <Tbody className="tableBody">
             {selectedItems.map((item, index) => (

--- a/src/features/review/shared/components/common/buttons/ButtonsForMultipleSelection/index.tsx
+++ b/src/features/review/shared/components/common/buttons/ButtonsForMultipleSelection/index.tsx
@@ -3,9 +3,8 @@ import { Button, Flex } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 
 import StudyContext from "@features/review/shared/context/StudiesContext";
-import { UseChangeStudySelectionStatus } from "../../../../services/useChangeStudySelectionStatus";
 import useSendDuplicatedStudies from "../../../../services/useSendDuplicatedStudies";
-import { FaCheckCircle, FaEye, FaTrashAlt } from "react-icons/fa";
+import { FaCheckCircle, FaEye } from "react-icons/fa";
 import { MdOutlineCleaningServices } from "react-icons/md";
 import useWindowWidth from "@features/shared/hooks/useWindowWidth";
 
@@ -55,17 +54,6 @@ export default function ButtonsForMultipleSelection({
     onShowSelectedArticles(false);
   };
 
-  const handleSendExcludedStudies = () => {
-    if (!articles || Object.keys(articles).length <= 1) return;
-    UseChangeStudySelectionStatus({
-      status: "EXCLUDED",
-      studyReviewId: [...Object.values(articles).map((art) => art.id)],
-      criterias: [],
-    });
-    studyContext?.clearSelectedArticles();
-    onShowSelectedArticles(false);
-  };
-
   return articles && Object.keys(articles).length > 1 ? (
     <Flex gap=".5rem" flexDirection={window > 1000 ? "row" : "column"}>
       {window > 1000 && (
@@ -111,16 +99,6 @@ export default function ButtonsForMultipleSelection({
       </Button>
       {window > 1000 && (
         <>
-          <Button
-            sx={buttonSX}
-            bg="#EBF0F3"
-            _hover={{ bg: "white", color: "#263C56", boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)"}}
-            transition="0.2s ease-in-out"
-            onClick={handleSendExcludedStudies}
-            leftIcon={<FaTrashAlt color="red"/>}
-          >
-            {t("buttonsForMultipleSelection.markAsExcluded")}
-          </Button>
           <Button
             sx={buttonSX}
             bg="#EBF0F3"

--- a/src/features/review/shared/components/common/buttons/ButtonsForMultipleSelection/index.tsx
+++ b/src/features/review/shared/components/common/buttons/ButtonsForMultipleSelection/index.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { SetStateAction, useContext } from "react";
 import { Button, Flex } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 
@@ -24,12 +24,14 @@ interface ButtonsForMultipleSelectionProps {
   onShowSelectedArticles: (showSelected: boolean) => void;
   isShown: boolean;
   reloadArticles: () => Promise<any>;
+  setIsMultipleSelectionEnable: React.Dispatch<SetStateAction<boolean>>;
 }
 
 export default function ButtonsForMultipleSelection({
   onShowSelectedArticles,
   isShown,
   reloadArticles,
+  setIsMultipleSelectionEnable
 }: ButtonsForMultipleSelectionProps) {
   const window = useWindowWidth();
   const studyContext = useContext(StudyContext);
@@ -45,6 +47,12 @@ export default function ButtonsForMultipleSelection({
   });
 
   const articles = studyContext?.selectedArticles;
+
+  if(articles && Object.keys(articles).length > 1){
+    setIsMultipleSelectionEnable(true);
+  } else {
+    setIsMultipleSelectionEnable(false);
+  }
 
   const handleSendDuplicatedStudies = async () => {
     await sendDuplicatedStudies();

--- a/src/features/review/shared/components/common/buttons/ButtonsForMultipleSelection/index.tsx
+++ b/src/features/review/shared/components/common/buttons/ButtonsForMultipleSelection/index.tsx
@@ -55,9 +55,8 @@ export default function ButtonsForMultipleSelection({
   };
 
   return articles && Object.keys(articles).length > 1 ? (
-    <Flex gap=".5rem" flexDirection={window > 1000 ? "row" : "column"}>
-      {window > 1000 && (
-        (!isShown ? (
+    <Flex gap={window > 1350 ? ".5rem" : ".2rem"} flexDirection={window > 1350 ? "row" : "column"}>
+      {!isShown ? (
           <Button
             sx={buttonSX}
             bg="#EBF0F3"
@@ -83,9 +82,8 @@ export default function ButtonsForMultipleSelection({
           >
             {t("buttonsForMultipleSelection.showAll")}
           </Button>
-        ))
-      )}
-
+        )
+      }
 
       <Button
         sx={buttonSX}
@@ -97,23 +95,20 @@ export default function ButtonsForMultipleSelection({
       >
         {t("buttonsForMultipleSelection.markAsDuplicated")}
       </Button>
-      {window > 1000 && (
-        <>
-          <Button
-            sx={buttonSX}
-            bg="#EBF0F3"
-            _hover={{ bg: "white", color: "#263C56", boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)"}}
-            transition="0.2s ease-in-out"
-            onClick={() => {
-              studyContext.clearSelectedArticles();
-              onShowSelectedArticles(false);
-            }}
-            leftIcon={<MdOutlineCleaningServices color="orange"/>}
-          >
-            {t("buttonsForMultipleSelection.clearSelection")}
-          </Button>
-        </>
-      )}
+
+      <Button
+        sx={buttonSX}
+        bg="#EBF0F3"
+        _hover={{ bg: "white", color: "#263C56", boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)"}}
+        transition="0.2s ease-in-out"
+        onClick={() => {
+          studyContext.clearSelectedArticles();
+          onShowSelectedArticles(false);
+        }}
+        leftIcon={<MdOutlineCleaningServices color="orange"/>}
+      >
+        {t("buttonsForMultipleSelection.clearSelection")}
+      </Button>
     </Flex>
   ) : null;
 }

--- a/src/features/review/shared/components/common/buttons/ButtonsForMultipleSelection/index.tsx
+++ b/src/features/review/shared/components/common/buttons/ButtonsForMultipleSelection/index.tsx
@@ -63,7 +63,7 @@ export default function ButtonsForMultipleSelection({
   };
 
   return articles && Object.keys(articles).length > 1 ? (
-    <Flex gap={window > 1350 ? ".5rem" : ".2rem"} flexDirection={window > 1350 ? "row" : "column"}>
+    <Flex gap={window > 1400 ? ".5rem" : ".2rem"} flexDirection={window > 1400 ? "row" : "column"}>
       {!isShown ? (
           <Button
             sx={buttonSX}

--- a/src/features/review/shared/styles/executionStyles.ts
+++ b/src/features/review/shared/styles/executionStyles.ts
@@ -11,7 +11,7 @@ export const inputconteiner = {
   width: "100%",
   m: "0 0 1rem 0",
   justifyContent: "space-between",
-  alignItems: "center",
+  alignItems: "start",
 };
 
 export const ckconteiner = {

--- a/src/features/review/summarization-graphics/pages/Graphics/index.tsx
+++ b/src/features/review/summarization-graphics/pages/Graphics/index.tsx
@@ -96,12 +96,12 @@ export default function Graphics() {
 
   return (
     <FlexLayout navigationType="Accordion">
-      <Flex justifyContent="space-between" alignItems="flex-start" w="100%" mb="1rem">
+      <Flex justifyContent="space-between" alignItems="flex-start" w="100%" mb="1rem" h={displayedFilters.length > 0 ? "10rem" : undefined} position="relative">
         <Flex flexDirection="column" gap="0.75rem">
           <Header text={t("header")} />
 
-          {displayedFilters.length > 0 && window > 1000 && (
-            <Flex flexDirection="column" gap="0.5rem">
+          {displayedFilters.length > 0 && (
+            <Flex flexDirection="column" gap="0.5rem" position="absolute" bottom="0">
               <Text fontWeight="semibold" fontSize="lg" color="#263C56">
                 {t("filtersArea.heading")}
               </Text>


### PR DESCRIPTION
## Summary
This PR improves responsiveness for the language/study base addition component and the multiple selection buttons, and restores the filter area on smaller screens in the Graphics page.

---

## Changes

### Planning Pages
- Readjusts the width of the language and database addition component for better responsiveness

### Selection / Extraction Pages
- Removes the unused "mark as excluded" button
- Adjusts the layout of the `ButtonsForMultipleSelection` component
- Prevents multiple selection buttons from overlapping the search input
- Corrects the responsiveness of the text input on the Selection and Extraction pages
- Displays `ButtonsForMultipleSelection` as a column on screens smaller than 1400px

### Graphics Page
- Restores the filter area on smaller screens

---

## Screenshots

### Planning Pages

#### Language Addition Component

<img width="575" height="767" alt="Captura de tela 2026-07-14 104327" src="https://github.com/user-attachments/assets/fca028c1-9fa4-4838-8195-70f47ce64159" />

#### Database Addition Component

<img width="576" height="767" alt="Captura de tela 2026-07-14 104351" src="https://github.com/user-attachments/assets/80ce4251-8f24-48bf-8d6e-5367cd9d8f8f" />

### Selection / Extraction

#### Small Screens

<img width="574" height="767" alt="Captura de tela 2026-07-14 104419" src="https://github.com/user-attachments/assets/f863c8eb-1551-4168-b10e-28c50a7005e8" />

#### Big Screens

<img width="1006" height="849" alt="Captura de tela 2026-07-14 104443" src="https://github.com/user-attachments/assets/cc236aff-75a2-4104-ba28-755724549af7" />

### Graphics

<img width="539" height="715" alt="Captura de tela 2026-07-14 104518" src="https://github.com/user-attachments/assets/da39a2b1-3463-453f-8942-586ea7f601f0" />
