### PR TITLE
feat: add conditional pagination to graphics

### DIFF
--- a/src/features/review/summarization-graphics/components/tables/ChartTable/ChartExpanded/index.tsx
+++ b/src/features/review/summarization-graphics/components/tables/ChartTable/ChartExpanded/index.tsx
@@ -401,16 +401,18 @@ export default function ChartExpanded({
           </Tbody>
         </Table>
       </TableContainer>
-      <PaginationControl
-        currentPage={currentPage}
-        itensPerPage={itensPerPageUI}
-        quantityOfPages={quantityOfPages}
-        handleNextPage={handleNextPage}
-        handlePrevPage={handlePrevPage}
-        handleBackToInitial={handleBackToInitial}
-        handleGoToFinal={handleGoToFinal}
-       changeQuantityOfItens={handleChangeItensPerPage}
-      />
+      {articles.length >= 20 && (
+        <PaginationControl
+          currentPage={currentPage}
+          itensPerPage={itensPerPageUI}
+          quantityOfPages={quantityOfPages}
+          handleNextPage={handleNextPage}
+          handlePrevPage={handlePrevPage}
+          handleBackToInitial={handleBackToInitial}
+          handleGoToFinal={handleGoToFinal}
+          changeQuantityOfItens={handleChangeItensPerPage}
+        />
+      )}
     </Box>
   );
 }

--- a/src/features/review/summarization-graphics/components/tables/ChartTable/GenericExpandedTable/index.tsx
+++ b/src/features/review/summarization-graphics/components/tables/ChartTable/GenericExpandedTable/index.tsx
@@ -211,7 +211,7 @@ export function GenericExpandedTable<T>({
         </Table>
       </TableContainer>
 
-      {!isExporting && data.length > 10 && (
+      {!isExporting && data.length >= 20 && (
         <Box 
           display="flex" 
           w="100%" 

--- a/src/features/review/summarization-graphics/components/tables/PickManyItemTable/index.tsx
+++ b/src/features/review/summarization-graphics/components/tables/PickManyItemTable/index.tsx
@@ -161,7 +161,7 @@ export function PickManyItemTable({ data, options, studyIds }: Props) {
         </Table>
       </TableContainer>
 
-      {!isExporting && (
+      {!isExporting && rows.length >= 20 && (
         <PaginationControl
           currentPage={currentPage}
           itensPerPage={itensPerPage}

--- a/src/features/review/summarization-graphics/components/tables/TextualTable/index.tsx
+++ b/src/features/review/summarization-graphics/components/tables/TextualTable/index.tsx
@@ -295,16 +295,18 @@ export default function TextualTable({
         </Table>
       </TableContainer>
 
-      <PaginationControl
-        currentPage={currentPage}
-        itensPerPage={itensPerPageUI}
-        quantityOfPages={quantityOfPages}
-        handleNextPage={handleNextPage}
-        handlePrevPage={handlePrevPage}
-        handleBackToInitial={handleBackToInitial}
-        handleGoToFinal={handleGoToFinal}
-        changeQuantityOfItens={handleChangeItensPerPage}
-      />
+      {articles.length >= 20 && (
+        <PaginationControl
+          currentPage={currentPage}
+          itensPerPage={itensPerPageUI}
+          quantityOfPages={quantityOfPages}
+          handleNextPage={handleNextPage}
+          handlePrevPage={handlePrevPage}
+          handleBackToInitial={handleBackToInitial}
+          handleGoToFinal={handleGoToFinal}
+          changeQuantityOfItens={handleChangeItensPerPage}
+        />
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
## What was done?
This PR adds and standardizes conditional pagination for the components in the Summarization > Graphics section. The pagination display is now configured to trigger only when the number of records is greater than or equal to 20.

Changes made:
GenericExpandedTable: Updated the pagination logic; the condition was changed from data.length > 10 to data.length >= 20.

PickManyItemTable: Added a condition to check if rows.length >= 20.

TextualTable: Added a condition to check if articles.length >= 20.

ChartExpanded: Added a condition to check if articles.length >= 20.