### PR TITLE
GM-fix-correct-date-update-in-search-session-modal

### DIFF
--- a/src/features/review/execution-identification/pages/Identification/subcomponents/modals/IdentificationModal/index.tsx
+++ b/src/features/review/execution-identification/pages/Identification/subcomponents/modals/IdentificationModal/index.tsx
@@ -59,6 +59,7 @@ function IdentificationModal({
 }: IdentificationModalProps) {
   const [searchString, setSearchString] = useState<string>("");
   const [comment, setComment] = useState<string>("");
+  const [date, setDate] = useState<string>(getCurrentDate());
   const [isError, setIsError] = useState(false);
   const { isOpen, onClose, onOpen } = useDisclosure();
   const { t } = useTranslation("review/execution-identification");
@@ -86,6 +87,7 @@ function IdentificationModal({
     mutate,
     searchString,
     comment,
+    date,
     type
   });
 
@@ -103,6 +105,7 @@ function IdentificationModal({
           if (selectedSession) {
             setSearchString(selectedSession.searchString);
             setComment(selectedSession.additionalInfo);
+            setDate(formatTimestampToInputDate(selectedSession.timestamp));
           }
         } catch (error) {
           const toast = useToaster();
@@ -146,7 +149,7 @@ function IdentificationModal({
     onClose();
   };
 
-  const getCurrentDate = () => {
+  function getCurrentDate() {
     const today = new Date();
     const year = today.getFullYear();
     const month = String(today.getMonth() + 1).padStart(2, "0");
@@ -156,6 +159,15 @@ function IdentificationModal({
 
   function removeReferenceFile(index: number) {
     setReferenceFiles(referenceFiles.filter((_, i) => i !== index));
+  }
+
+  function formatTimestampToInputDate(timestamp: string) {
+    const d = new Date(timestamp);
+    if (isNaN(d.getTime())) return getCurrentDate();
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
   }
 
   return (
@@ -169,7 +181,7 @@ function IdentificationModal({
         <ModalBody>
           <FormControl mb={4}>
             <FormLabel>{t("dataBaseCard.identificationModal.input.date")}</FormLabel>
-            <Input type="date" defaultValue={getCurrentDate()} />
+            <Input type="date" value={date} onChange={(e) => setDate(e.target.value)} />
           </FormControl>
           <FormControl mb={4} isRequired isInvalid={isError}>
             <FormLabel>{t("dataBaseCard.identificationModal.input.searchString.label")}</FormLabel>

--- a/src/features/review/execution-identification/services/useUpdateSession.tsx
+++ b/src/features/review/execution-identification/services/useUpdateSession.tsx
@@ -20,6 +20,7 @@ interface UpdateSessionProps {
     >;
     searchString: string;
     comment: string;
+    date: string;
     type: string;
 }
 
@@ -28,6 +29,7 @@ export default function useUpdateSession({
   mutate,
   searchString,
   comment,
+  date,
   type
 }: UpdateSessionProps) {
     const toast = useToaster();
@@ -42,7 +44,8 @@ export default function useUpdateSession({
             const response = await Axios.put(url, {
                 "searchString": searchString,
                 "additionalInfo": comment,
-                "source": type
+                "source": type,
+                "timestamp": new Date(date).toISOString()
             });
             
             if(!response) throw new Error();


### PR DESCRIPTION
## Summary

The date field in the `IdentificationModal` was previously read-only in practice — it always displayed the current date (`getCurrentDate()`) as a `defaultValue` and had no `onChange` handler, so users couldn't actually edit it, and the selected session's existing timestamp was never loaded into the field. This PR makes the date field fully controlled and editable, and wires the updated value through to the update request.

## Changes

- **`IdentificationModal/index.tsx`**
  - Introduced a `date` state variable, initialized with `getCurrentDate()`.
  - Converted the date `Input` from an uncontrolled field (`defaultValue`) to a controlled field (`value` + `onChange`), allowing users to modify it.
  - When a session is selected, `date` is now populated from `selectedSession.timestamp` via a new `formatTimestampToInputDate` helper, instead of always defaulting to today.
  - Added `formatTimestampToInputDate(timestamp)`, which parses the timestamp into `YYYY-MM-DD` format expected by the `date` input, falling back to `getCurrentDate()` if the timestamp is invalid.
  - Refactored `getCurrentDate` from an arrow function to a function declaration so it can be safely referenced before its definition (hoisting) inside `formatTimestampToInputDate`.
  - Passed `date` into the `useUpdateSession` hook call.

- **`useUpdateSession.tsx`**
  - Added `date` to `UpdateSessionProps`.
  - Included `date` as a parameter in the hook and forwarded it to the PUT request as `timestamp: new Date(date).toISOString()`.

### Notes / Follow-ups
- `formatTimestampToInputDate` falls back to today's date on invalid/malformed timestamps — worth confirming this is the desired UX vs. showing an error state.
- No changes were made to the create-session flow; this PR is scoped to the update modal only.