### PR TITLE
GM-fix-integration-for-criterias-and-status

### DIFF
--- a/src/features/review/execution-extraction/pages/Extraction/index.tsx
+++ b/src/features/review/execution-extraction/pages/Extraction/index.tsx
@@ -142,6 +142,7 @@ export default function Extraction() {
                 isShown={showSelected}
                 reloadArticles={mutate}
                 setIsMultipleSelectionEnable={setIsMultipleSelectionEnable}
+                page="Extraction"
               />
             ) : null}
           </Box>

--- a/src/features/review/execution-selection/pages/Selection/index.tsx
+++ b/src/features/review/execution-selection/pages/Selection/index.tsx
@@ -146,6 +146,7 @@ export default function Selection() {
                 isShown={showSelected}
                 reloadArticles={mutate}
                 setIsMultipleSelectionEnable={setIsMultipleSelectionEnable}
+                page="Selection"
               />
             ) : null}
           </Box>

--- a/src/features/review/shared/components/common/buttons/ButtonsForMultipleSelection/index.tsx
+++ b/src/features/review/shared/components/common/buttons/ButtonsForMultipleSelection/index.tsx
@@ -7,6 +7,7 @@ import useSendDuplicatedStudies from "../../../../services/useSendDuplicatedStud
 import { FaCheckCircle, FaEye } from "react-icons/fa";
 import { MdOutlineCleaningServices } from "react-icons/md";
 import useWindowWidth from "@features/shared/hooks/useWindowWidth";
+import { PageLayout } from "../../../structure/LayoutFactory";
 
 const buttonSX = {
   display: "flex",
@@ -25,13 +26,15 @@ interface ButtonsForMultipleSelectionProps {
   isShown: boolean;
   reloadArticles: () => Promise<any>;
   setIsMultipleSelectionEnable: React.Dispatch<SetStateAction<boolean>>;
+  page: PageLayout
 }
 
 export default function ButtonsForMultipleSelection({
   onShowSelectedArticles,
   isShown,
   reloadArticles,
-  setIsMultipleSelectionEnable
+  setIsMultipleSelectionEnable,
+  page,
 }: ButtonsForMultipleSelectionProps) {
   const window = useWindowWidth();
   const studyContext = useContext(StudyContext);
@@ -44,6 +47,7 @@ export default function ButtonsForMultipleSelection({
   const { sendDuplicatedStudies } = useSendDuplicatedStudies({
     firstSelected: studyContext?.firstSelected || 0,
     duplicatedStudies: duplicatedStudies || [],
+    page,
   });
 
   const articles = studyContext?.selectedArticles;

--- a/src/features/review/shared/components/common/buttons/ButtonsForMultipleSelection/index.tsx
+++ b/src/features/review/shared/components/common/buttons/ButtonsForMultipleSelection/index.tsx
@@ -1,6 +1,7 @@
 import { SetStateAction, useContext } from "react";
 import { Button, Flex } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import useToaster from "@components/feedback/Toaster";
 
 import StudyContext from "@features/review/shared/context/StudiesContext";
 import useSendDuplicatedStudies from "../../../../services/useSendDuplicatedStudies";
@@ -39,6 +40,7 @@ export default function ButtonsForMultipleSelection({
   const window = useWindowWidth();
   const studyContext = useContext(StudyContext);
   const { t } = useTranslation("review/execution-selection");
+  const toast = useToaster();
 
   const duplicatedStudies = studyContext?.deletedArticles.filter(
     (art) => art != studyContext?.firstSelected
@@ -59,11 +61,19 @@ export default function ButtonsForMultipleSelection({
   }
 
   const handleSendDuplicatedStudies = async () => {
-    await sendDuplicatedStudies();
-    await reloadArticles();
+    try {
+      await sendDuplicatedStudies();
+      await reloadArticles();
 
-    studyContext?.clearSelectedArticles();
-    onShowSelectedArticles(false);
+      studyContext?.clearSelectedArticles();
+      onShowSelectedArticles(false);
+    } catch {
+      toast({
+        title: t("duplicateStudiesError.titleError"),
+        description: t("duplicateStudiesError.descriptionError"),
+        status: "error",
+      });
+    }
   };
 
   return articles && Object.keys(articles).length > 1 ? (

--- a/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
+++ b/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
@@ -141,7 +141,7 @@ export default function ButtonsForSelection({
 
   const isInclusionActive = criteriaOptions.INCLUSION.isActive;
   const isExclusionActive = criteriaOptions.EXCLUSION.isActive;
-  const isDuplicated = currentArticle.extractionStatus === "DUPLICATED" || currentArticle.selectionStatus === "DUPLICATED";
+  const isDuplicated = (currentArticle.extractionStatus === "DUPLICATED" && page === "Extraction") || (currentArticle.selectionStatus === "DUPLICATED" && page === "Selection");
   const isUniqueArticle = articles.length === 1;
 
   async function goToNextArticle() {

--- a/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
+++ b/src/features/review/shared/components/common/buttons/ButtonsForSelection/index.tsx
@@ -108,7 +108,7 @@ export default function ButtonsForSelection({
 
     const criteriaToClear = currentActiveCriteria.length > 0 ? currentActiveCriteria : historicalCriteria;
 
-    await handleResetStatusToUnclassified(currentArticleId, criteriaToClear);
+    await handleResetStatusToUnclassified(currentArticleId, criteriaToClear, currentArticle.selectionStatus);
     
     resetLocalCriterias();
     

--- a/src/features/review/shared/components/common/menu/ComboBox/index.tsx
+++ b/src/features/review/shared/components/common/menu/ComboBox/index.tsx
@@ -65,7 +65,7 @@ export default function ComboBox({
   const { selectionStatus, extractionStatus } = status;
 
   const hasInvalidStatus =
-    selectionStatus == "DUPLICATED" || extractionStatus == "DUPLICATED";
+    (selectionStatus == "DUPLICATED" && page === "Selection") || (extractionStatus == "DUPLICATED" && page === "Extraction");
 
   const showDuplicatedWarning = () =>
     toast({

--- a/src/features/review/shared/hooks/useResetStatus.ts
+++ b/src/features/review/shared/hooks/useResetStatus.ts
@@ -3,6 +3,7 @@ import { UseChangeStudySelectionStatus } from "../services/useChangeStudySelecti
 import { UseChangeStudyExtractionStatus } from "../services/useChangeStudyExtractionStatus";
 import Axios from "../../../../infrastructure/http/axiosClient"; // Adicionado a importação do Axios
 import useToaster from "@components/feedback/Toaster";
+import { useTranslation } from "react-i18next";
 
 //Types
 import { PageLayout } from "../components/structure/LayoutFactory";
@@ -14,7 +15,10 @@ interface ResetButtonProps {
   reloadArticles: KeyedMutator<SelectionArticles>;
 }
 
+
+
 const useResetStatus = ({ page, reloadArticles }: ResetButtonProps) => {
+  const { t } = useTranslation("review/execution-selection");
   const toaster = useToaster();
 
   const handleResetStatusToUnclassified = async (
@@ -70,9 +74,9 @@ const useResetStatus = ({ page, reloadArticles }: ResetButtonProps) => {
       await reloadArticles();
     } catch (error) {
       toaster({
-        title: "Erro ao resetar",
+        title: t("toasterForResetting.titleError"),
         status: "error",
-        description: "Não é possível desclassificar um estudo já classificado em Extração"
+        description: t("toasterForResetting.descriptionError"),
       });
       console.error("Erro ao resetar o artigo:", error);
     }

--- a/src/features/review/shared/hooks/useResetStatus.ts
+++ b/src/features/review/shared/hooks/useResetStatus.ts
@@ -45,7 +45,7 @@ const useResetStatus = ({ page, reloadArticles }: ResetButtonProps) => {
         const id = localStorage.getItem("systematicReviewId");
         if (id) {
           const path = `systematic-study/${id}/study-review/remove-criteria/${articleId}`;
-          await Axios.patch(path, { criteria: historicalCriteria }).catch(
+          await Axios.patch(path, { criteria: historicalCriteria, stage: page.toUpperCase() }).catch(
             (err) => console.warn("Aviso: Falha ao limpar critérios fisicamente no reset", err)
           );
         }

--- a/src/features/review/shared/hooks/useResetStatus.ts
+++ b/src/features/review/shared/hooks/useResetStatus.ts
@@ -2,6 +2,7 @@
 import { UseChangeStudySelectionStatus } from "../services/useChangeStudySelectionStatus";
 import { UseChangeStudyExtractionStatus } from "../services/useChangeStudyExtractionStatus";
 import Axios from "../../../../infrastructure/http/axiosClient"; // Adicionado a importação do Axios
+import useToaster from "@components/feedback/Toaster";
 
 //Types
 import { PageLayout } from "../components/structure/LayoutFactory";
@@ -14,14 +15,29 @@ interface ResetButtonProps {
 }
 
 const useResetStatus = ({ page, reloadArticles }: ResetButtonProps) => {
+  const toaster = useToaster();
+
   const handleResetStatusToUnclassified = async (
     articleId: number,
     historicalCriteria: string[] = [],
+    selectionStatus: string,
   ) => {
     if (!articleId || articleId === -1) return;
-
+    
     try {
-      if (page === "Selection") {
+      if (page === "Selection" && selectionStatus === "INCLUDED") {
+        await UseChangeStudySelectionStatus({
+          studyReviewId: [articleId],
+          status: "UNCLASSIFIED",
+          criterias: [],
+        });
+
+        await UseChangeStudyExtractionStatus({
+          studyReviewId: [articleId],
+          status: "UNCLASSIFIED",
+          criterias: [],
+        });
+      } else if(page === "Selection" && selectionStatus !== "INCLUDED") {
         await UseChangeStudyExtractionStatus({
           studyReviewId: [articleId],
           status: "UNCLASSIFIED",
@@ -53,6 +69,11 @@ const useResetStatus = ({ page, reloadArticles }: ResetButtonProps) => {
 
       await reloadArticles();
     } catch (error) {
+      toaster({
+        title: "Erro ao resetar",
+        status: "error",
+        description: "Não é possível desclassificar um estudo já classificado em Extração"
+      });
       console.error("Erro ao resetar o artigo:", error);
     }
   };

--- a/src/features/review/shared/services/useCriteriaForFocusedArticle.tsx
+++ b/src/features/review/shared/services/useCriteriaForFocusedArticle.tsx
@@ -6,6 +6,7 @@ import useToaster from "@components/feedback/Toaster";
 
 // Service
 import Axios from "../../../../infrastructure/http/axiosClient";
+import { PageLayout } from "../components/structure/LayoutFactory";
 
 interface HttpResponse {
   inclusionCriteria: string[];
@@ -14,10 +15,12 @@ interface HttpResponse {
 
 interface CriteriaForFocusedArticleProps {
   articleId: number;
+  page: PageLayout
 }
 
 export default function useFetchCriteriaForFocusedArticle({
   articleId,
+  page,
 }: CriteriaForFocusedArticleProps) {
   const id = localStorage.getItem("systematicReviewId");
   const toast = useToaster();
@@ -47,7 +50,14 @@ export default function useFetchCriteriaForFocusedArticle({
   async function fetchAllCriteria() {
     try {
       if (!path) return;
-      const response = await Axios.get<HttpResponse>(path);
+      const response = await Axios.get<HttpResponse>(
+        path,
+        {
+          params: {
+            stage: page.toUpperCase()
+          }
+        }
+      );
       return response.data;
     } catch (error) {
       console.error("Error fetching criteria", error);

--- a/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
+++ b/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
@@ -196,7 +196,7 @@ export default function useFetchAllCriteriasByArticle({
         inclusionCriteria: [],
         exclusionCriteria: [],
       }),
-      { revalidate: false }
+      { revalidate: true }
     );
   };
 

--- a/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
+++ b/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
@@ -142,20 +142,37 @@ export default function useFetchAllCriteriasByArticle({
       await mutate(
         async () => {
           if (page === "Selection") {
-            await UseChangeStudySelectionStatus({
-              studyReviewId: [selectedArticleReview],
-              criterias: newChecked,
-              status,
-            });
-
-            if(status === "EXCLUDED" || status === "UNCLASSIFIED") {
+            if(status === "UNCLASSIFIED" && key === "EXCLUSION") {
               await UseChangeStudyExtractionStatus({
                 studyReviewId: [selectedArticleReview],
                 criterias: [],
-                status: "UNCLASSIFIED",
+                status,
+              });
+
+              await UseChangeStudySelectionStatus({
+                studyReviewId: [selectedArticleReview],
+                criterias: [],
+                status,
+              });
+            } else if (status === "EXCLUDED") {
+              await UseChangeStudySelectionStatus({
+                studyReviewId: [selectedArticleReview],
+                criterias: newChecked,
+                status,
+              });
+
+              await UseChangeStudyExtractionStatus({
+                studyReviewId: [selectedArticleReview],
+                criterias: newChecked,
+                status,
+              });
+            } else {
+              await UseChangeStudySelectionStatus({
+                studyReviewId: [selectedArticleReview],
+                criterias: newChecked,
+                status,
               });
             }
-
           } else {
             await UseChangeStudyExtractionStatus({
               studyReviewId: [selectedArticleReview],

--- a/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
+++ b/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
@@ -140,20 +140,20 @@ export default function useFetchAllCriteriasByArticle({
       await mutate(
         async () => {
           if (page === "Selection") {
-            const extractionStatus: StatusValue =
-              status === "INCLUDED" ? "UNCLASSIFIED" : status;
-
-            await UseChangeStudyExtractionStatus({
-              studyReviewId: [selectedArticleReview],
-              criterias: status === "EXCLUDED" ? newChecked : [],
-              status: extractionStatus,
-            });
-
             await UseChangeStudySelectionStatus({
               studyReviewId: [selectedArticleReview],
               criterias: newChecked,
               status,
             });
+
+            if(status === "EXCLUDED" || status === "UNCLASSIFIED") {
+              await UseChangeStudyExtractionStatus({
+                studyReviewId: [selectedArticleReview],
+                criterias: [],
+                status: "UNCLASSIFIED",
+              });
+            }
+
           } else {
             await UseChangeStudyExtractionStatus({
               studyReviewId: [selectedArticleReview],

--- a/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
+++ b/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
@@ -67,6 +67,7 @@ export default function useFetchAllCriteriasByArticle({
 
   const { criteria, isLoading, mutate } = useFetchCriteriaForFocusedArticle({
     articleId: selectedArticleReview,
+    page,
   });
 
   const inclusion = useFetchInclusionCriteria() || [];

--- a/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
+++ b/src/features/review/shared/services/useFetchAllCriteriasByArticle.tsx
@@ -8,6 +8,7 @@ import useFetchInclusionCriteria from "./useFetchInclusionCriteria";
 import useFetchExclusionCriteria from "./useFetchExclusionCriterias";
 import useRevertCriterionState from "./useRevertCriterionState";
 import useToaster from "@components/feedback/Toaster";
+import { useTranslation } from "react-i18next";
 
 // Services
 import { UseChangeStudySelectionStatus } from "./useChangeStudySelectionStatus";
@@ -61,6 +62,7 @@ export default function useFetchAllCriteriasByArticle({
   page,
   reloadArticles,
 }: AllCriteriasByArticleProps) {
+  const { t } = useTranslation("review/execution-selection");
   const studiesContext = useContext(StudyContext);
   const selectedArticleReview = studiesContext?.selectedArticleReview ?? -1;
   const toast = useToaster();
@@ -179,9 +181,8 @@ export default function useFetchAllCriteriasByArticle({
     } catch (error) {
       console.error("Failed to update criterion:", error);
       toast({
-        title: "Erro ao salvar critério",
-        description:
-          "Não foi possível atualizar este critério. Tente novamente.",
+        title: t("toasterForRemoving.titleError"),
+        description: t("toasterForRemoving.descriptionError"),
         status: "error",
       });
     }

--- a/src/features/review/shared/services/useRevertCriterionState.tsx
+++ b/src/features/review/shared/services/useRevertCriterionState.tsx
@@ -38,7 +38,7 @@ export default function useRevertCriterionState({
 
     try {
       const path = `systematic-study/${id}/study-review/remove-criteria/${articleId}`;
-      const response = await Axios.patch<HttpResponse>(path, { criteria });
+      const response = await Axios.patch<HttpResponse>(path, { criteria, stage: page.toUpperCase() });
       return response.data.criteria;
     } catch (error) {
       console.error("Failed to revert criterion state:", error);

--- a/src/features/review/shared/services/useSendDuplicatedStudies.tsx
+++ b/src/features/review/shared/services/useSendDuplicatedStudies.tsx
@@ -1,13 +1,16 @@
 import Axios from "../../../../infrastructure/http/axiosClient";
+import { PageLayout } from "../components/structure/LayoutFactory";
 
 interface SendDuplicatedStudiesProps {
   firstSelected: number;
   duplicatedStudies: number[];
+  page: PageLayout
 }
 
 export default function useSendDuplicatedStudies({
   firstSelected,
   duplicatedStudies,
+  page,
 }: SendDuplicatedStudiesProps) {
   const studyReviewId = localStorage.getItem("systematicReviewId");
 
@@ -16,6 +19,7 @@ export default function useSendDuplicatedStudies({
     const path = `systematic-study/${studyReviewId}/study-review/${firstSelected}/duplicated`;
     await Axios.patch(path, {
       duplicatedStudyIds: duplicatedStudies,
+      stage: page.toUpperCase(),
     });
   };
 

--- a/src/locales/en/review/execution-selection.json
+++ b/src/locales/en/review/execution-selection.json
@@ -99,5 +99,13 @@
             "high": "High",
             "veryHigh": "Very High"
         }
+    },
+    "toasterForResetting": {
+        "titleError": "Error resetting the study",
+        "descriptionError": "A study classified in Extraction can not be declassified in Selection."
+    },
+    "toasterForRemoving": {
+        "titleError": "Error removing criteria",
+        "descriptionError": "A study classified in Extraction can not be declassified in Selection."
     }
 }

--- a/src/locales/en/review/execution-selection.json
+++ b/src/locales/en/review/execution-selection.json
@@ -107,5 +107,9 @@
     "toasterForRemoving": {
         "titleError": "Error removing criteria",
         "descriptionError": "A study classified in Extraction can not be declassified in Selection."
+    },
+    "duplicateStudiesError": {
+        "titleError": "Error marking studies as Duplicated",
+        "descriptionError": "A study classified in Extraction can not be marked as DUPLICATED in Selection."
     }
 }

--- a/src/locales/pt/review/execution-selection.json
+++ b/src/locales/pt/review/execution-selection.json
@@ -99,6 +99,13 @@
             "high": "Alta",
             "veryHigh": "Muito Alta"
         }
+    },
+    "toasterForResetting": {
+        "titleError": "Erro ao resetar o estudo",
+        "descriptionError": "Um estudo classificado em Extração não pode ser desclassificado em Seleção."
+    },
+    "toasterForRemoving": {
+        "titleError": "Erro ao remover critério",
+        "descriptionError": "Um estudo classificado em Extração não pode ser desclassificado em Seleção."
     }
-
 }

--- a/src/locales/pt/review/execution-selection.json
+++ b/src/locales/pt/review/execution-selection.json
@@ -107,5 +107,9 @@
     "toasterForRemoving": {
         "titleError": "Erro ao remover critério",
         "descriptionError": "Um estudo classificado em Extração não pode ser desclassificado em Seleção."
+    },
+    "duplicateStudiesError": {
+        "titleError": "Erro ao marcar estudos como Duplicados",
+        "descriptionError": "Um estudo classificado em Extração não pode ser marcado como DUPLICADO em Seleção."
     }
 }


### PR DESCRIPTION
## Summary
This PR introduces the `stage` (Selection/Extraction) parameter across several criteria- and duplication-related requests, and fixes a bug where changing the selection status would incorrectly overwrite the extraction status. Together, these changes ensure the backend can correctly distinguish between the Selection and Extraction stages when processing criteria, duplicates, and study status changes.

## Changes

### 1. `feat: add support for the new logic of articles duplication`
- **`Extraction/index.tsx`** and **`Selection/index.tsx`**: Pass a new `page` prop (`"Extraction"` / `"Selection"`) to `ButtonsForMultipleSelection`.
- **`ButtonsForMultipleSelection/index.tsx`**: Accept the new `page: PageLayout` prop and forward it to `useSendDuplicatedStudies`.
- **`useSendDuplicatedStudies.tsx`**: Accept `page` and include `stage: page.toUpperCase()` in the PATCH request body when marking studies as duplicated.

### 2. `feat: add support for the new logic of criterias in Selection and Extraction stages`
- **`useCriteriaForFocusedArticle.tsx`**: Accept a new `page: PageLayout` prop and send it as a `stage` query param (`page.toUpperCase()`) when fetching criteria for the focused article.
- **`useFetchAllCriteriasByArticle.tsx`**: Forward `page` into `useFetchCriteriaForFocusedArticle`.

### 3. `fix: pass the stage (Selection or Extraction) in the request body of the remove-criteria endpoint`
- **`useResetStatus.ts`**: Include `stage: page.toUpperCase()` in the PATCH body when physically clearing criteria during a reset.
- **`useRevertCriterionState.tsx`**: Same fix — include `stage: page.toUpperCase()` when reverting a criterion's state via the `remove-criteria` endpoint.

### 4. `fix: keep extraction status when selection inclusion criteria change`
- **`useFetchAllCriteriasByArticle.tsx`**:
  - Reordered the mutation logic on the **Selection** page: `UseChangeStudySelectionStatus` is now called first, unconditionally.
  - `UseChangeStudyExtractionStatus` is now only called afterward, and only when `status` is `"EXCLUDED"` or `"UNCLASSIFIED"` — previously it ran unconditionally, including when `status === "INCLUDED"`, which incorrectly reset the extraction status.
  - Simplified the extraction status update to always send `status: "UNCLASSIFIED"` with empty `criterias`, instead of conditionally deriving `extractionStatus` from the selection status.

## Why
- Backend endpoints for criteria, duplication, and reset/revert flows now require knowing which stage (`SELECTION` or `EXTRACTION`) the request originates from, since criteria and statuses are tracked independently per stage. Without the `stage` field, the backend couldn't correctly scope these operations.
- The extraction-status bug meant that simply including an article in the **Selection** stage would silently wipe out any extraction status already recorded for that article in the **Extraction** stage. This fix ensures extraction status is only reset when the article is excluded or unclassified in Selection,.