### PR TITLE
feat(sources): add validation modal to prevent deletion of sources with classified articles

### DIFF
--- a/src/features/review/execution-identification/pages/Identification/subcomponents/modals/DeleteSessionModal/index.tsx
+++ b/src/features/review/execution-identification/pages/Identification/subcomponents/modals/DeleteSessionModal/index.tsx
@@ -22,24 +22,35 @@ interface DeleteSessionModalProps {
   mutate: KeyedMutator<Session[]>;
 }
 
-type SelectionStatus = "INCLUDED" | "EXCLUDED" | "DUPLICATED" | "UNCLASSIFIED";
+const BLOCKED_STATUSES = ["INCLUDED", "EXCLUDED", "DUPLICATED"];
+
+function getSelectionStatus(study: any): string {
+  return (study.selectionStatus ?? study.selection ?? "").toUpperCase();
+}
 
 async function canDeleteSession(
   reviewId: string,
-  sessionId: string,
-  numberOfRelatedStudies: number
+  sessionId: string
 ): Promise<boolean> {
-  if (numberOfRelatedStudies === 0) return true;
+  let page = 0;
+  const size = 50;
 
-  const size = Math.max(numberOfRelatedStudies, 1);
-  const path = `systematic-study/${reviewId}/find-by-search-session/${sessionId}`;
-  const response = await Axios.get(path, { params: { page: 0, size } });
-  const studies = response.data?.studyReviews ?? [];
+  while (true) {
+    const path = `systematic-study/${reviewId}/find-by-search-session/${sessionId}`;
+    const response = await Axios.get(path, { params: { page, size } });
+    const studies: any[] = response.data?.studyReviews ?? [];
+    const totalPages: number = response.data?.totalPages ?? 1;
 
-  const blockedStatuses: SelectionStatus[] = ["INCLUDED", "EXCLUDED", "DUPLICATED"];
-  return !studies.some((s: any) =>
-    blockedStatuses.includes(s.selectionStatus as SelectionStatus)
-  );
+    const hasBlocked = studies.some((s) =>
+      BLOCKED_STATUSES.includes(getSelectionStatus(s))
+    );
+
+    if (hasBlocked) return false;
+    if (page >= totalPages - 1) break;
+    page++;
+  }
+
+  return true;
 }
 
 export default function DeleteSessionModal({
@@ -52,9 +63,7 @@ export default function DeleteSessionModal({
 
   return (
     <DeleteWithValidationModal
-      checkCanDelete={() =>
-        canDeleteSession(reviewId, session.id, session.numberOfRelatedStudies)
-      }
+      checkCanDelete={() => canDeleteSession(reviewId, session.id)}
       onConfirm={async () => {
         await UseDeleteSession({ sessionId: session.id, mutate });
       }}

--- a/src/features/review/planning-protocol/components/common/modals/DeleteSourceModal/index.tsx
+++ b/src/features/review/planning-protocol/components/common/modals/DeleteSourceModal/index.tsx
@@ -9,22 +9,75 @@ interface DeleteSourceModalProps {
   onClose: () => void;
 }
 
-type SelectionStatus = "INCLUDED" | "EXCLUDED" | "DUPLICATED" | "UNCLASSIFIED";
+interface Session {
+  id: string;
+  numberOfRelatedStudies: number;
+}
+
+const BLOCKED_STATUSES = ["INCLUDED", "EXCLUDED", "DUPLICATED"];
+
+function getSelectionStatus(study: any): string {
+  return (study.selectionStatus ?? study.selection ?? "").toUpperCase();
+}
+
+async function fetchSessionsForSource(
+  reviewId: string,
+  sourceName: string
+): Promise<Session[]> {
+  const variations = [
+    sourceName,
+    sourceName.toUpperCase(),
+    sourceName.toLowerCase(),
+  ];
+
+  const sessionMap = new Map<string, Session>();
+
+  for (const name of variations) {
+    try {
+      const path = `systematic-study/${reviewId}/search-session-source/${encodeURIComponent(name)}`;
+      const response = await Axios.get(path);
+      const sessions: Session[] = response.data?.searchSessions ?? [];
+      sessions.forEach((s) => sessionMap.set(s.id, s));
+    } catch {
+    }
+  }
+
+  return [...sessionMap.values()];
+}
 
 async function canDeleteSource(
   reviewId: string,
   sourceName: string
 ): Promise<boolean> {
-  const path = `systematic-study/${reviewId}/search-source/${encodeURIComponent(sourceName)}`;
-  const response = await Axios.get(path);
-  const studies = response.data?.studyReviews ?? [];
+  const sessions = await fetchSessionsForSource(reviewId, sourceName);
 
-  if (studies.length === 0) return true;
+  if (sessions.length === 0) return true;
 
-  const blockedStatuses: SelectionStatus[] = ["INCLUDED", "EXCLUDED", "DUPLICATED"];
-  return !studies.some((s: any) =>
-    blockedStatuses.includes(s.selectionStatus as SelectionStatus)
-  );
+  for (const session of sessions) {
+    if (session.numberOfRelatedStudies === 0) continue;
+
+    let page = 0;
+    const size = 50;
+
+    while (true) {
+      const articlesPath = `systematic-study/${reviewId}/find-by-search-session/${session.id}`;
+      const articlesResponse = await Axios.get(articlesPath, {
+        params: { page, size },
+      });
+      const studies: any[] = articlesResponse.data?.studyReviews ?? [];
+      const totalPages: number = articlesResponse.data?.totalPages ?? 1;
+
+      const hasBlocked = studies.some((s) =>
+        BLOCKED_STATUSES.includes(getSelectionStatus(s))
+      );
+
+      if (hasBlocked) return false;
+      if (page >= totalPages - 1) break;
+      page++;
+    }
+  }
+
+  return true;
 }
 
 export default function DeleteSourceModal({


### PR DESCRIPTION
## Validação antes de excluir fonte em Sources
### Implementa modal de confirmação ao deletar uma base de dados em Sources, seguindo o mesmo comportamento já existente em Identification.
### Alterações:
- DeleteSourceModal — novo modal que verifica todas as sessões da source em Identification antes de permitir a exclusão, tentando múltiplas variações do nome para lidar com inconsistências de case entre protocolo e banco
- DeleteSessionModal — refatorado para usar o DeleteWithValidationModal, com paginação completa e leitura correta do campo de status do backend