### PR TITLE
BO-115-fix(auth): add full internationalization support for authentication forms

### DIFF
--- a/src/features/auth/components/forms/ForgotPassword/index.tsx
+++ b/src/features/auth/components/forms/ForgotPassword/index.tsx
@@ -1,6 +1,7 @@
 // External library
 import { useState } from "react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 // Styles
 import "../styles.css";
@@ -10,6 +11,7 @@ export default function ForgotPassword({
 }: {
   redirectFormLogin: () => void;
 }) {
+  const { t } = useTranslation("landing/homepage");
   const [email, setEmail] = useState<string>("");
   const [error, setError] = useState<string>("");
 
@@ -21,7 +23,7 @@ export default function ForgotPassword({
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!validateEmail(email)) {
-      setError("Invalid email");
+      setError(t("forgotPassword.invalidEmail"));
       return;
     } else {
       // lógica de envio do email de recuperação de senha (auth)
@@ -31,10 +33,10 @@ export default function ForgotPassword({
 
   return (
     <form onSubmit={handleSubmit}>
-      <h2>Forgot Password</h2>
+      <h2>{t("forgotPassword.title")}</h2>
       <div className="contentForm">
         <div className="inputGroup">
-          <label htmlFor="forgot-email">Email</label>
+          <label htmlFor="forgot-email">{t("forgotPassword.email")}</label>
           <input
             type="text"
             id="forgot-email"
@@ -45,9 +47,9 @@ export default function ForgotPassword({
         {error && <p className="error">{error}</p>}
         <div className="actions">
           <Link to="#" onClick={redirectFormLogin}>
-            Back to Login
+            {t("forgotPassword.backToLogin")}
           </Link>
-          <button type="submit">Recover Password</button>
+          <button type="submit">{t("forgotPassword.submit")}</button>
         </div>
       </div>
     </form>

--- a/src/features/auth/components/forms/SignIn/Index.tsx
+++ b/src/features/auth/components/forms/SignIn/Index.tsx
@@ -1,17 +1,14 @@
-// External library
-import { Link } from "react-router-dom";
-
-// Hooks
-import useHandleLogin from "../../../hooks/useHandleLogin";
-
-// Styles
+import { useTranslation } from "react-i18next";
 import "../styles.css";
+import useHandleLogin from "../../../hooks/useHandleLogin";
+import { Link } from "react-router-dom";
 
 export default function FormLogin({
   redirectForgotPassword,
 }: {
   redirectForgotPassword: () => void;
 }) {
+  const { t } = useTranslation("landing/homepage");
   const {
     credentials,
     errors,
@@ -22,41 +19,45 @@ export default function FormLogin({
 
   return (
     <form onSubmit={handleSubmit}>
-      <h2>Log In</h2>
+      <h2>{t("login.title")}</h2>
       <div className="contentForm">
+        {/* Usuário */}
         <div className="inputGroup">
-          <label htmlFor="email">Username</label>
+          <label htmlFor="username">{t("login.username")}</label>
           <input
             type="text"
             id="username"
+            placeholder={t("login.placeholders.username")}
             value={credentials.username}
-            onChange={(e) => {
-              handleChangeCredentials("username", e.target.value);
-            }}
+            onChange={(e) => handleChangeCredentials("username", e.target.value)}
             className={errors.username ? "inputError" : ""}
           />
           {errors.username && <p className="error">{errors.username}</p>}
         </div>
+
+        {/* Senha */}
         <div className="inputGroup">
-          <label htmlFor="password">Password</label>
+          <label htmlFor="password">{t("login.password")}</label>
           <input
             type="password"
             id="password"
+            placeholder={t("login.placeholders.password")}
             value={credentials.password}
-            onChange={(e) => {
-              handleChangeCredentials("password", e.target.value);
-            }}
+            onChange={(e) => handleChangeCredentials("password", e.target.value)}
             className={errors.password ? "inputError" : ""}
           />
           {errors.password && <p className="error">{errors.password}</p>}
         </div>
+
         {errors && <p className="error">{errors.general}</p>}
+
+        {/* Ações */}
         <div className="actions">
           <button type="submit" disabled={isSubmitting}>
-            {isSubmitting ? "Is submitting..." : "Log in"}
+            {isSubmitting ? t("login.submitting") : t("login.submit")}
           </button>
           <Link to="#" onClick={redirectForgotPassword}>
-            Forgot Password?
+            {t("login.forgotPassword")}
           </Link>
         </div>
       </div>

--- a/src/features/auth/components/forms/Signup/Index.tsx
+++ b/src/features/auth/components/forms/Signup/Index.tsx
@@ -1,12 +1,16 @@
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import i18n from "i18next";
 import "../styles.css";
 import useHandleSignup from "../../../hooks/useHandleRegister";
 
-const Countries = ["Argentina", "Australia", "Austria", "Belgium", "Brazil", "Canada", "Chile", "China",
-  "Denmark", "Egypt", "Finland", "France", "Germany", "Greece", "India", "Iran", "Ireland", "Israel",
-  "Italy", "Japan", "Mexico", "Netherlands", "New Zealand", "Norway", "Pakistan", "Portugal",
-  "Saudi Arabia", "South Africa", "South Korea", "Spain", "Sweden", "Switzerland", "Turkey",
-  "United Kingdom", "United States", "Colombia"].sort();
+const CountryCodes = [
+  "AR", "AU", "AT", "BE", "BR", "CA", "CL", "CN", "CO",
+  "DK", "EG", "FI", "FR", "DE", "GR", "IN", "IR", "IE", "IL",
+  "IT", "JP", "MX", "NL", "NZ", "NO", "PK", "PT",
+  "SA", "ZA", "KR", "ES", "SE", "CH", "TR",
+  "GB", "US"
+];
 
 export default function FormSignup({
   redirectFormLogin,
@@ -14,6 +18,14 @@ export default function FormSignup({
   redirectFormLogin: () => void;
   closeModal: () => void;
 }) {
+  const { t } = useTranslation("landing/homepage");
+  // instância do tradutor nativo de países baseado no idioma do i18n
+  const countryNames = new Intl.DisplayNames([i18n.language || "pt"], { type: "region" });
+  const sortedCountries = CountryCodes.map((code) => ({
+    code,
+    name: countryNames.of(code) || code,
+  })).sort((a, b) => a.name.localeCompare(b.name));
+
   const {
     createUser,
     errors,
@@ -34,13 +46,15 @@ export default function FormSignup({
 
   return (
     <form onSubmit={handleRegister}>
-      <h2>Sign Up</h2>
+      <h2>{t("signUp.title")}</h2>
       <div className="contentForm">
+        {/* Username */}
         <div className="inputGroup">
-          <label htmlFor="username">Username</label>
+          <label htmlFor="username">{t("signUp.username")}</label>
           <input
             type="text"
             id="username"
+            placeholder={t("signUp.placeholders.username")}
             value={username}
             onChange={(e) =>
               handleChangeUserInformations("username", e.target.value)
@@ -50,11 +64,13 @@ export default function FormSignup({
           {errors.username && <p className="error">{errors.username}</p>}
         </div>
 
+        {/* Name */}
         <div className="inputGroup">
-          <label htmlFor="name">Name</label>
+          <label htmlFor="name">{t("signUp.name")}</label>
           <input
             type="text"
             id="name"
+            placeholder={t("signUp.placeholders.name")}
             value={name}
             onChange={(e) =>
               handleChangeUserInformations("name", e.target.value)
@@ -64,11 +80,13 @@ export default function FormSignup({
           {errors.name && <p className="error">{errors.name}</p>}
         </div>
 
+        {/* Email */}
         <div className="inputGroup">
-          <label htmlFor="email">Email</label>
+          <label htmlFor="email">{t("signUp.email")}</label>
           <input
             type="text"
             id="email"
+            placeholder={t("signUp.placeholders.email")}
             value={email}
             onChange={(e) =>
               handleChangeUserInformations("email", e.target.value)
@@ -78,11 +96,13 @@ export default function FormSignup({
           {errors.email && <p className="error">{errors.email}</p>}
         </div>
 
+        {/* Affiliation */}
         <div className="inputGroup">
-          <label htmlFor="affiliation">Affiliation</label>
+          <label htmlFor="affiliation">{t("signUp.affiliation")}</label>
           <input
             type="text"
             id="affiliation"
+            placeholder={t("signUp.placeholders.affiliation")}
             value={affiliation}
             onChange={(e) =>
               handleChangeUserInformations("affiliation", e.target.value)
@@ -92,8 +112,9 @@ export default function FormSignup({
           {errors.affiliation && <p className="error">{errors.affiliation}</p>}
         </div>
 
+        {/* Country (Traduzido e Ordenado) */}
         <div className="inputGroup">
-          <label htmlFor="country">Country</label>
+          <label htmlFor="country">{t("signUp.country")}</label>
           <select
             id="country"
             value={country}
@@ -102,22 +123,24 @@ export default function FormSignup({
             }
             className={errors.country ? "inputError" : ""}
           >
-            <option value="">Select Country</option>
-            {Countries.map((c) => (
-              <option key={c} value={c}>
-                {c}
+            <option value="">{t("signUp.selectCountry")}</option>
+            {sortedCountries.map((c) => (
+              <option key={c.code} value={c.name}>
+                {c.name}
               </option>
             ))}
-            <option value="Other">Other...</option>
+            <option value="Other">{t("signUp.otherCountry")}</option>
           </select>
           {errors.country && <p className="error">{errors.country}</p>}
         </div>
 
+        {/* Password */}
         <div className="inputGroup">
-          <label htmlFor="password">Password</label>
+          <label htmlFor="password">{t("signUp.password")}</label>
           <input
             type="password"
             id="password"
+            placeholder={t("signUp.placeholders.password")}
             value={password}
             onChange={(e) =>
               handleChangeUserInformations("password", e.target.value)
@@ -127,11 +150,13 @@ export default function FormSignup({
           {errors.password && <p className="error">{errors.password}</p>}
         </div>
 
+        {/* Confirm Password */}
         <div className="inputGroup">
-          <label htmlFor="confirmPassword">Confirm password</label>
+          <label htmlFor="confirmPassword">{t("signUp.confirmPassword")}</label>
           <input
             type="password"
             id="confirmPassword"
+            placeholder={t("signUp.placeholders.confirmPassword")}
             value={confirmPassword}
             onChange={(e) =>
               handleChangeUserInformations("confirmPassword", e.target.value)
@@ -143,12 +168,13 @@ export default function FormSignup({
           )}
         </div>
 
+        {/* Actions */}
         <div className="actions">
           <button type="submit" disabled={isSubmitting}>
-            {isSubmitting ? "Submitting..." : "Create Account"}
+            {isSubmitting ? t("signUp.submitting") : t("signUp.submit")}
           </button>
           <Link to="#" onClick={redirectFormLogin}>
-            Already have an account?
+            {t("signUp.alreadyHaveAccount")}
           </Link>
         </div>
       </div>

--- a/src/features/auth/hooks/useHandleLogin.ts
+++ b/src/features/auth/hooks/useHandleLogin.ts
@@ -1,5 +1,6 @@
 // External library
 import { useState } from "react";
+import { useTranslation } from "react-i18next"; // 1. Importação do useTranslation
 
 // Hooks
 import { useAuthStore } from "../store/useAuthStore";
@@ -17,6 +18,7 @@ import useToaster from "@components/feedback/Toaster";
 import useValidatorSQLInjection from "@features/shared/hooks/useValidatorSQLInjection";
 
 export default function useHandleLogin() {
+  const { t } = useTranslation("landing/homepage");
   const [credentials, setCredentials] = useState<AccessCredentials>({
     username: "",
     password: "",
@@ -29,11 +31,8 @@ export default function useHandleLogin() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { toGo } = useNavigation();
-
   const { login } = useAuthStore();
-
   const Toaster = useToaster();
-
   const validator = useValidatorSQLInjection();
 
   const handleChangeCredentials = (
@@ -54,18 +53,19 @@ export default function useHandleLogin() {
     };
 
     if (!credentials.username) {
-      errors.username = "Please, enter your username";
+      errors.username = t("login.errors.username");
     }
 
     if (!credentials.password) {
-      errors.password = "Please, enter your password";
-    }
-
-    if (
+      errors.password = t("login.errors.password");
+    } else if (
       credentials.password.length < PASSWORD_LENGHT.MIN ||
       credentials.password.length > PASSWORD_LENGHT.MAX
     ) {
-      errors.password = `Password must be at least ${PASSWORD_LENGHT.MIN} characters and at most ${PASSWORD_LENGHT.MAX} characters`;
+      errors.password = t("login.errors.passwordLength", {
+        min: PASSWORD_LENGHT.MIN,
+        max: PASSWORD_LENGHT.MAX,
+      });
     }
 
     setErrors((prev) => ({ ...prev, ...errors }));
@@ -81,7 +81,13 @@ export default function useHandleLogin() {
 
     setIsSubmitting(true);
     try {
-      if(!(validator({value: credentials.password}) && validator({value: credentials.username}))) return;
+      if(
+        !(
+          validator({ value: credentials.password }) &&
+          validator({ value: credentials.username })
+        )
+      ) return;
+
       const loginResult = await login(credentials);
 
       if (isLeft(loginResult)) {
@@ -92,25 +98,24 @@ export default function useHandleLogin() {
         }));
         handleChangeCredentials("password", "");
         Toaster({
-          title: "Login failed",
+          title: t("login.toast.failedTitle"),
           description: errorMessage,
           status: "error",
         });
         return;
       }
+      
       toGo("/home");
 
-      setIsSubmitting(false);
-      
     } catch (error) {
       setErrors((prev) => ({
         ...prev,
-        general: "Wrong username or password",
+        general: t("login.errors.wrongCredentials"),
       }));
       handleChangeCredentials("password", "");
       Toaster({
-        title: "Login failed",
-        description: "Incorrect username or password.",
+        title: t("login.toast.failedTitle"),
+        description: t("login.toast.incorrectCredentialsDesc"),
         status: "error",
       });
     } finally {

--- a/src/features/auth/hooks/useHandleRegister.tsx
+++ b/src/features/auth/hooks/useHandleRegister.tsx
@@ -1,5 +1,6 @@
 // External library
 import { useState } from "react";
+import { useTranslation } from "react-i18next"; // 1. Importação do useTranslation
 
 // Components
 import useToaster from "@components/feedback/Toaster";
@@ -13,6 +14,17 @@ import { ApplicationError } from "@features/shared/errors/base/ApplicationError"
 
 // Constants
 import { PASSWORD_LENGHT } from "@features/auth/constants/user";
+
+// Types
+import type { User } from "@features/auth/types";
+
+// Guards
+import { isLeft } from "@features/shared/errors/pattern/Either";
+import errorFactory from "@features/shared/errors/factory/errorFactory";
+
+interface RegisterUser extends User {
+  confirmPassword: string;
+}
 
 const defaultRegister = {
   username: "",
@@ -34,18 +46,9 @@ const defaultErrors = {
   confirmPassword: "",
 };
 
-// Types
-import type { User } from "@features/auth/types";
-
-// Guards
-import { isLeft } from "@features/shared/errors/pattern/Either";
-import errorFactory from "@features/shared/errors/factory/errorFactory";
-
-interface RegisterUser extends User {
-  confirmPassword: string;
-}
-
 const useHandleRegister = (redirectFormLogin: () => void) => {
+  const { t } = useTranslation("landing/homepage");
+
   const [createUser, setCreateUser] = useState<RegisterUser>(defaultRegister);
   const [errors, setErrors] =
     useState<Record<keyof RegisterUser, string>>(defaultErrors);
@@ -82,40 +85,43 @@ const useHandleRegister = (redirectFormLogin: () => void) => {
     };
 
     if (!username) {
-      errors.username = "Please, enter your username";
+      errors.username = t("signUp.errors.username");
     }
 
     if (!name) {
-      errors.name = "Please, enter your full name";
+      errors.name = t("signUp.errors.name");
     }
 
     if (!email) {
-      errors.email = "Please, enter your email";
+      errors.email = t("signUp.errors.email");
     } else if (!validateEmail(email)) {
-      errors.email = "Invalid email address format";
+      errors.email = t("signUp.errors.invalidEmail");
     }
 
     if (!affiliation) {
-      errors.affiliation = "Please, enter your affiliation";
+      errors.affiliation = t("signUp.errors.affiliation");
     }
 
     if (!country) {
-      errors.country = "Please, enter your country";
+      errors.country = t("signUp.errors.country");
     }
 
     if (!password) {
-      errors.password = "Please, enter your password";
+      errors.password = t("signUp.errors.password");
     } else if (
       password.length < PASSWORD_LENGHT.MIN ||
       password.length > PASSWORD_LENGHT.MAX
     ) {
-      errors.password = `Password must be at least ${PASSWORD_LENGHT.MIN} characters and at most ${PASSWORD_LENGHT.MAX} characters`;
+      errors.password = t("signUp.errors.passwordLength", {
+        min: PASSWORD_LENGHT.MIN,
+        max: PASSWORD_LENGHT.MAX,
+      });
     }
 
     if (!confirmPassword) {
-      errors.confirmPassword = "Please, confirm your password";
+      errors.confirmPassword = t("signUp.errors.confirmPassword");
     } else if (password !== confirmPassword) {
-      errors.confirmPassword = "Passwords do not match";
+      errors.confirmPassword = t("signUp.errors.passwordMismatch");
     }
 
     setErrors(errors);
@@ -132,7 +138,17 @@ const useHandleRegister = (redirectFormLogin: () => void) => {
     try {
       const { confirmPassword, ...rest } = createUser;
 
-      if(!(validator({value: createUser.affiliation}) && validator({value: createUser.confirmPassword}) && validator({value: createUser.country}) && validator({value: createUser.email}) && validator({value: createUser.name}) && validator({value: createUser.password}) && validator({value: createUser.username}))) return;
+      if(
+        !(
+          validator({value: createUser.affiliation}) && 
+          validator({value: createUser.confirmPassword}) && 
+          validator({value: createUser.country}) && 
+          validator({value: createUser.email}) && 
+          validator({value: createUser.name}) && 
+          validator({value: createUser.password}) && 
+          validator({value: createUser.username})
+        )
+      ) return;
         
       const result = await registerUser(rest);
 
@@ -146,31 +162,31 @@ const useHandleRegister = (redirectFormLogin: () => void) => {
             setErrors((prev) => ({ ...prev, email: error.message }));
           } else {
             toast({
-              title: "Error",
+              title: t("signUp.toast.errorTitle"),
               status: "error",
               description: error.message,
             });
           }
         } else {
           toast({
-            title: "Unexpected Error",
+            title: t("signUp.toast.unexpectedErrorTitle"),
             status: "error",
-            description: "An unknown error format was received.",
+            description: t("signUp.toast.unexpectedErrorDesc"),
           });
         }
         return;
       }
 
       toast({
-        title: "Account created",
+        title: t("signUp.toast.successTitle"),
         status: "success",
-        description: `You can now log in with your account, ${result.value.username}.`,
+        description: t("signUp.toast.successDesc", { username: result.value.username }),
       });
       redirectFormLogin();
     } catch (error) {
       const appError = errorFactory("custom", (error as Error).message);
       toast({
-        title: "Unexpected error",
+        title: t("signUp.toast.unexpectedErrorTitle"),
         status: "error",
         description: appError.value.message,
       });

--- a/src/features/review/execution-identification/services/useHandleExportedFiles.tsx
+++ b/src/features/review/execution-identification/services/useHandleExportedFiles.tsx
@@ -5,9 +5,10 @@ import Axios from "../../../../infrastructure/http/axiosClient";
 import useToaster from "@components/feedback/Toaster";
 import { KeyedMutator } from "swr";
 import { InvalidEntry } from "@features/review/shared/types/StudiesContextInterface";
+import { useTranslation } from "react-i18next";
 
 interface Props {
-  mutate: KeyedMutator<
+  mutate: KeyedMutator <
     {
       id: string;
       systematicStudyd: string;
@@ -33,6 +34,7 @@ const useHandleExportedFiles = ({
   const [referenceFiles, setReferenceFiles] = useState<File[]>([]);
   const [source, setSource] = useState("");
   const toast = useToaster();
+  const { t } = useTranslation("review/execution-identification");
 
   const id = localStorage.getItem("systematicReviewId");
 
@@ -58,8 +60,8 @@ const useHandleExportedFiles = ({
 
       if (isDuplicate) {
         toast({
-          title: "Duplicate file",
-          description: "This file already exists!",
+          title: t("upload.duplicateFile.title"),
+          description: t("upload.duplicateFile.description"),
           status: "warning",
         });
       } else {
@@ -126,15 +128,14 @@ const useHandleExportedFiles = ({
           invalidArticles,
           setInvalidEntries
         );
-
         toast({
-          title: "Some files need revision",
-          description: `${invalidArticles.length} file(s) could not be processed.`,
+          title: t("upload.someFilesNeedRevision.title"),
+          description: `${invalidArticles.length} ${t("upload.someFilesNeedRevision.description")}`,
           status: "warning",
         });
       } else {
         toast({
-          title: "Files uploaded successfully",
+          title: t("upload.success.title"),
           status: "success",
         });
       }

--- a/src/features/review/planning-protocol/components/common/tables/InfosTable/index.tsx
+++ b/src/features/review/planning-protocol/components/common/tables/InfosTable/index.tsx
@@ -7,6 +7,7 @@ import { Table, Tbody, Tr, Td, TableContainer, Input, Flex, Thead, Th } from "@c
 import useCreateProtocol from "@features/review/planning-protocol/services/useCreateProtocol";
 import EventButton from "@components/common/buttons/EventButton";
 import useToaster from "@components/feedback/Toaster";
+import { useTranslation } from "react-i18next";
 
 interface InfosTableProps {
   AddTexts: string[];
@@ -35,6 +36,7 @@ export default function InfosTable({
 }: InfosTableProps) {
   const { sendAddText } = useCreateProtocol();
   const toaster = useToaster();
+  const { t } = useTranslation("review/planning-protocol");
 
   const [newText, setNewText] = useState("");
   const [referenceCode, setReferenceCode] = useState("");
@@ -67,8 +69,8 @@ export default function InfosTable({
     const codes = getAllCodes(editIdx);
     if (codeToSave && codes.includes(codeToSave)) {
       toaster({
-        title: `The reference code '${codeToSave}' is already in use.`,
-        description: "Please choose another one.",
+        title: `${t("selectionAndExtraction.input.extractionQuestions.toaster.duplicated.title1")} '${codeToSave}' ${t("selectionAndExtraction.input.extractionQuestions.toaster.duplicated.title2")}`,
+        description: t("selectionAndExtraction.input.extractionQuestions.toaster.duplicated.description"),
         status: "error",
       });
       return false;
@@ -114,8 +116,8 @@ export default function InfosTable({
 
     if (code && existingCodes.includes(code)) {
       toaster({
-        title: `The reference code '${code}' is already in use.`,
-        description: "Please choose another one.",
+        title: `${t("selectionAndExtraction.input.extractionQuestions.toaster.duplicated.title1")} '${code}' ${t("selectionAndExtraction.input.extractionQuestions.toaster.duplicated.title2")}`,
+        description: t("selectionAndExtraction.input.extractionQuestions.toaster.duplicated.description"),
         status: "error",
       });
       return true;
@@ -138,14 +140,13 @@ export default function InfosTable({
   };
 
   return (
- 
-    <TableContainer 
-      w="100%" 
-      sx={{ 
-        ...tbConteiner, 
+    <TableContainer
+      w="100%"
+      sx={{
+        ...tbConteiner,
         h: tableHeight || tbConteiner.h,
         width: "100% !important",
-        maxWidth: "100% !important"
+        maxWidth: "100% !important",
       }}
     >
       <Table variant="simple" size="md" w="100%">

--- a/src/locales/en/landing/homepage.json
+++ b/src/locales/en/landing/homepage.json
@@ -49,5 +49,75 @@
     "about": "About",
     "suggestions": "Suggestions",
     "socialMedia": "Social Media"
+  },
+  "login": {
+    "title": "Login",
+    "username": "Username",
+    "password": "Password",
+    "forgotPassword": "Forgot password?",
+    "submit": "Login",
+    "submitting": "Logging in...",
+    "placeholders": {
+      "username": "Enter your username",
+      "password": "Enter your password"
+    },
+    "errors": {
+      "username": "Please, enter your username",
+      "password": "Please, enter your password",
+      "passwordLength": "Password must be at least {{min}} characters and at most {{max}} characters"
+    },
+    "toast": {
+      "failedTitle": "Login failed",
+      "incorrectCredentialsDesc": "Incorrect username or password."
+    }
+  },
+  "forgotPassword": {
+    "title": "Forgot Password",
+    "email": "Email",
+    "invalidEmail": "Invalid email format",
+    "backToLogin": "Back to Login",
+    "submit": "Recover Password"
+  },
+  "signUp": {
+    "title": "Sign Up",
+    "username": "Username",
+    "name": "Name",
+    "email": "Email",
+    "affiliation": "Affiliation",
+    "country": "Country",
+    "selectCountry": "Select Country",
+    "otherCountry": "Other...",
+    "password": "Password",
+    "confirmPassword": "Confirm password",
+    "submit": "Create Account",
+    "submitting": "Submitting...",
+    "alreadyHaveAccount": "Already have an account?",
+    "placeholders": {
+      "username": "Enter your username",
+      "name": "Enter your full name",
+      "email": "Enter your email",
+      "affiliation": "Enter your affiliation",
+      "password": "Enter your password",
+      "confirmPassword": "Confirm your password"
+    },
+    "errors": {
+      "username": "Please, enter your username",
+      "name": "Please, enter your full name",
+      "email": "Please, enter your email",
+      "invalidEmail": "Invalid email address format",
+      "affiliation": "Please, enter your affiliation",
+      "country": "Please, enter your country",
+      "password": "Please, enter your password",
+      "passwordLength": "Password must be at least {{min}} characters and at most {{max}} characters",
+      "confirmPassword": "Please, confirm your password",
+      "passwordMismatch": "Passwords do not match"
+    },
+    "toast": {
+      "errorTitle": "Error",
+      "unexpectedErrorTitle": "Unexpected Error",
+      "unexpectedErrorDesc": "An unknown error format was received.",
+      "successTitle": "Account created",
+      "successDesc": "You can now log in with your account, {{username}}."
+    }
   }
 }

--- a/src/locales/en/review/execution-identification.json
+++ b/src/locales/en/review/execution-identification.json
@@ -95,5 +95,18 @@
     "searchSessions": {
         "header": "Search Sessions",
         "back": "Back"
+    },
+    "upload": {
+        "duplicateFile": {
+            "title": "Duplicate file",
+            "description": "This file already exists!"
+        },
+        "someFilesNeedRevision": {
+            "title": "Some files need revision",
+            "description": "file(s) could not be processed."
+        },
+        "success": {
+            "title": "Files uploaded successfully"
+        }
     }
 }

--- a/src/locales/pt/landing/homepage.json
+++ b/src/locales/pt/landing/homepage.json
@@ -13,7 +13,7 @@
     "heading": "Pesquise mais, de qualquer lugar!",
     "text": "Potencialize suas pesquisas! Experimente nossa ferramenta gratuita para revisões sistemáticas - fácil de usar e ideal para pesquisadores e estudantes.",
     "signUp": "Cadastre-se já",
-    "alt": "Foto de diferentes dispositivos eletronicos conectados a ferramenta StArt - computador deskot, smart phone e tablet."
+    "alt": "Foto de diferentes dispositivos eletronicos conectados a ferramenta StArt - computador desktop, smartphone e tablet."
   },
   "about": {
     "title": "Sobre a ferramenta",
@@ -49,5 +49,76 @@
     "about": "Sobre",
     "suggestions": "Sugestões",
     "socialMedia": "Redes Sociais"
+  },
+  "login": {
+    "title": "Entrar",
+    "username": "Usuário",
+    "password": "Senha",
+    "forgotPassword": "Esqueceu a senha?",
+    "submit": "Entrar",
+    "submitting": "Entrando...",
+    "placeholders": {
+      "username": "Digite seu usuário",
+      "password": "Digite sua senha"
+    },
+    "errors": {
+      "username": "Por favor, informe seu usuário",
+      "password": "Por favor, informe sua senha",
+      "passwordLength": "A senha deve ter entre {{min}} e {{max}} caracteres",
+      "wrongCredentials": "Usuário ou senha incorretos"
+    },
+    "toast": {
+      "failedTitle": "Falha no login",
+      "incorrectCredentialsDesc": "Usuário ou senha incorretos."
+    }
+  },
+  "forgotPassword": {
+    "title": "Recuperar Senha",
+    "email": "E-mail",
+    "invalidEmail": "Formato de e-mail inválido",
+    "backToLogin": "Voltar para o Login",
+    "submit": "Recuperar Senha"
+  },
+  "signUp": {
+    "title": "Cadastrar",
+    "username": "Usuário",
+    "name": "Nome",
+    "email": "E-mail",
+    "affiliation": "Afiliação",
+    "country": "País",
+    "selectCountry": "Selecione o País",
+    "otherCountry": "Outro...",
+    "password": "Senha",
+    "confirmPassword": "Confirmar Senha",
+    "submit": "Criar Conta",
+    "submitting": "Cadastrando...",
+    "alreadyHaveAccount": "Já possui uma conta?",
+    "placeholders": {
+      "username": "Digite seu usuário",
+      "name": "Digite seu nome completo",
+      "email": "Digite seu e-mail",
+      "affiliation": "Digite sua afiliação",
+      "password": "Digite sua senha",
+      "confirmPassword": "Confirme sua senha"
+    },
+    "errors": {
+      "username": "Por favor, informe seu usuário",
+      "name": "Por favor, informe seu nome completo",
+      "email": "Por favor, informe seu e-mail",
+      "invalidEmail": "Formato de e-mail inválido",
+      "affiliation": "Por favor, informe sua afiliação",
+      "country": "Por favor, selecione seu país",
+      "password": "Por favor, informe sua senha",
+      "passwordLength": "A senha deve ter entre {{min}} e {{max}} caracteres",
+      "confirmPassword": "Por favor, confirme sua senha",
+      "passwordMismatch": "As senhas não coincidem"
+    },
+    "toast": {
+      "errorTitle": "Erro",
+      "unexpectedErrorTitle": "Erro Inesperado",
+      "unexpectedErrorDesc": "Um formato de erro desconhecido foi recebido.",
+      "successTitle": "Conta criada",
+      "successDesc": "Você já pode entrar com sua conta, {{username}}."
+    }
   }
 }

--- a/src/locales/pt/review/execution-identification.json
+++ b/src/locales/pt/review/execution-identification.json
@@ -95,5 +95,18 @@
     "searchSessions": {
         "header": "Sessões de Pesquisa",
         "back": "Voltar"
+    },
+    "upload": {
+        "duplicateFile": {
+            "title": "Arquivo duplicado",
+            "description": "Este arquivo já existe!"
+        },
+        "someFilesNeedRevision": {
+            "title": "Alguns arquivos precisam de revisão",
+            "description": "arquivo(s) não puderam ser processados."
+        },
+        "success": {
+            "title": "Arquivos enviados com sucesso"
+        }
     }
 }


### PR DESCRIPTION
### 1. Landing Page (Autenticação)
- **Login (`src/features/auth/components/forms/SignIn/Index.tsx` & `useHandleLogin.ts`):** 
  - Tradução dos rótulos (labels), mensagens de validação/erro e adição de novos *placeholders* nos campos.
<img width="1113" height="435" alt="image" src="https://github.com/user-attachments/assets/39a2753a-dea3-453d-a507-50c2aa849713" />
<img width="807" height="388" alt="image" src="https://github.com/user-attachments/assets/01ea1324-7912-4920-bad9-4a93e59f3ecd" />

- **Cadastro (`src/features/auth/components/forms/Signup/Index.tsx` & `useHandleRegister.tsx`):** 
  - Tradução completa dos campos, *placeholders*, validações de senha, erros de formulário e seleção dinâmica de países.
  
<img width="812" height="664" alt="image" src="https://github.com/user-attachments/assets/8dcf69be-c89c-4bb3-a6e2-ba189541327a" />

<img width="691" height="819" alt="image" src="https://github.com/user-attachments/assets/b3727b6a-13d5-4913-adf4-45966269942f" />


- **Recuperar Senha (`src/features/auth/components/forms/ForgotPassword/index.tsx`):** 
  - Tradução dos textos, botões e respostas do formulário.
<img width="875" height="279" alt="image" src="https://github.com/user-attachments/assets/3923d6e5-7ef4-49c2-a5ce-b74dfe6ffc33" />


### 2. Protocolo de Planejamento (`src/features/review/planning-protocol/...`)
- **Critérios de Elegibilidade (IC & EC):**
  - Tradução das notificações de erro (*toasts*) exibidas ao tentar cadastrar ou utilizar um código de referência duplicado tanto em **Critérios de Inclusão (IC)** quanto em **Critérios de Exclusão (EC)**.

<img width="1259" height="369" alt="image" src="https://github.com/user-attachments/assets/b42716c6-d9fd-414b-bd7e-4de03d7403db" />
<img width="1272" height="552" alt="image" src="https://github.com/user-attachments/assets/9d0b2de3-a73f-40a5-8480-3441e688d1b9" />

- **Questões de Pesquisa (Research Questions):**
  - Tradução do alerta de erro (*toast*) de código de referência duplicado (ex: ao cadastrar um `RQ` já existente).
  
<img width="1119" height="831" alt="image" src="https://github.com/user-attachments/assets/2479ee5c-d696-4d15-976f-6033c99e9529" />


  
### 3. Execução — Identificação (`src/features/review/execution/...`)
- **Upload de Arquivos de Busca:**
  - Adicionadas chaves de tradução e suporte a mensagens de *toast* para o fluxo de upload de arquivos nas sessões das bases de dados, cobrindo:
    - **Sucesso:** Envio de arquivos concluído com sucesso.
    - **Arquivo Duplicado:** Alerta informando que o arquivo já existe.
 
<img width="1115" height="787" alt="image" src="https://github.com/user-attachments/assets/d83294b7-e1f8-4ce4-91e7-74bc6dc0721c" />
