### PR TITLE
fix(extraction): i18n in form titles, multiselect usability and divid…

### DIFF
--- a/src/features/review/execution-extraction/components/forms/DataExtraction/index.tsx
+++ b/src/features/review/execution-extraction/components/forms/DataExtraction/index.tsx
@@ -167,7 +167,9 @@ export default function DataExtraction({
                 ? "EXTRACTION"
                 : "RISK_OF_BIAS";
             const formatedFormKey =
-              typeFormKey === "EXTRACTION" ? "Extraction" : "Risk of Bias";
+              typeFormKey === "EXTRACTION"
+                ? t("extractionForm.sectionTitle")
+                : t("extractionForm.riskOfBiasTitle");
             const isRiskOfBiasKey = typeFormKey === "RISK_OF_BIAS";
 
             if (
@@ -214,7 +216,7 @@ export default function DataExtraction({
 
             return (
               <Box key={sectionKey}>
-                {index > 0 && <Divider />}
+                {index > 0 && <Divider mb="3.5rem"/>}
                 <Box mb="1.5rem" px={{ base: "1rem", md: "2rem" }}>
                   <Heading
                     size="md"

--- a/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/MultiSelectionList/index.tsx
+++ b/src/features/review/execution-extraction/components/forms/DataExtraction/subcomponents/responses/MultiSelectionList/index.tsx
@@ -51,9 +51,10 @@ export default function MultiSelectionList({
           display="flex"
           flexDirection="column"
           gap="1rem"
-          overflowY="auto"
-          maxH="8rem"
-          padding="0.25rem"
+          p="0.75rem"
+          border="1px solid"
+          borderRadius="1rem"
+          borderColor={isInvalid ? "red.300" : "gray.200"}
         >
           {options.map((value) => (
             <Checkbox

--- a/src/locales/en/review/execution-extraction.json
+++ b/src/locales/en/review/execution-extraction.json
@@ -22,6 +22,8 @@
         "noChangesToast": {
             "title": "No changes made",
             "description": "Update at least one answer before submitting."
-        }
+        },
+        "sectionTitle": "Extraction",
+        "riskOfBiasTitle": "Risk of Bias"
     }
 }

--- a/src/locales/pt/review/execution-extraction.json
+++ b/src/locales/pt/review/execution-extraction.json
@@ -22,6 +22,8 @@
         "noChangesToast": {
             "title": "Nenhuma mudança foi feita",
             "description": "Atualize pelo menos uma resposta antes antes de reenviar."
-        }
+        },
+        "sectionTitle": "Extração",
+        "riskOfBiasTitle": "Risco de Viés"
     }
 }


### PR DESCRIPTION
### Arrumar a internacionalização no título das seções do formulário; fazer com que o campo de seleção múltipla fosse uma coisa só, não um container com scroll e arrumar o espaçamento entre o título da seção do Risco de Viés e a seção anterior, de Extração.

- Os títulos estavam sem internacionalização, mesmo com a língua portuguesa selecionada, continuava como "Extraction" ao invés de "Extração" e "Risk of Bias" ao invés de "Risco de Viés".

- O campo de seleção múltipla anteriormente era um container com scroll, dificultando a usabilidade.

- O traço que divide a parte de Risco de Viés estava muito colado com o fim da seção anterior, de Extração.

### Local da Alteração
<img width="213" height="918" alt="image" src="https://github.com/user-attachments/assets/e357b668-f989-4bcd-b023-231fa67eadb3" />

### Alteração 1:
<img width="552" height="510" alt="image" src="https://github.com/user-attachments/assets/42fe3dbd-3fb9-49af-aa90-ab01b1aa1dff" />

### Alteração 2:
<img width="491" height="385" alt="image" src="https://github.com/user-attachments/assets/e51869ce-6661-41e9-a02e-9837193ab649" />

### Alteração 3:
<img width="513" height="537" alt="image" src="https://github.com/user-attachments/assets/ba818390-1194-4366-ad12-5d0476d93519" />
