### PR TITLE
GM-fix-fetch-all-review-articles

### DIFF
--- a/src/features/review/shared/services/useGetAllReviewArticles.ts
+++ b/src/features/review/shared/services/useGetAllReviewArticles.ts
@@ -9,6 +9,8 @@ interface HttpResponse {
   studyReviews: ArticleInterface[] | StudyInterface[];
 }
 
+const PAGE_SIZE = 100;
+
 const useGetAllReviewArticles = () => {
   const id = localStorage.getItem("systematicReviewId");
   const { data, mutate, error, isLoading } = useSWR(
@@ -25,10 +27,24 @@ const useGetAllReviewArticles = () => {
 
   async function fetchAllArticlesReview() {
     try {
-      const response = await Axios.get<HttpResponse>(
-        `systematic-study/${id}/study-review`
-      );
-      return response.data.studyReviews || [];
+      const allArticles: (ArticleInterface | StudyInterface)[] = [];
+      let page = 0;
+      let hasMore = true;
+
+      while (hasMore) {
+        const response = await Axios.get<HttpResponse>(
+          `systematic-study/${id}/study-review`,
+          { params: { page, size: PAGE_SIZE } }
+        );
+
+        const pageData = response.data.studyReviews || [];
+        allArticles.push(...pageData);
+
+        hasMore = pageData.length === PAGE_SIZE;
+        page += 1;
+      }
+
+      return allArticles;
     } catch (error) {
       console.error("Error fetching articles", error);
       throw error;


### PR DESCRIPTION
## Summary
This PR fixes the `useGetAllReviewArticles` hook, which was only fetching the first page of study review articles (max 20) instead of all of them, causing the frontend to display an incomplete list even when the review had significantly more articles.

---

## Changes
### Review / Study Review Hook
- Adds pagination handling to `useGetAllReviewArticles`, fetching subsequent pages until a page returns fewer items than the requested size
- Ensures the hook actually returns **all** articles of a review, matching its name and expected behavior