### PR TITLE
GM-fix-column-visibility-on-smaller-screens

### DIFF
--- a/src/features/review/shared/components/common/tables/ArticlesTable/subcomponents/Expanded/index.tsx
+++ b/src/features/review/shared/components/common/tables/ArticlesTable/subcomponents/Expanded/index.tsx
@@ -25,6 +25,9 @@ import { RiCheckboxMultipleBlankFill } from "react-icons/ri";
 // Context
 import StudyContext from "@features/review/shared/context/StudiesContext";
 
+// Hooks
+import useWindowWidth from "@features/shared/hooks/useWindowWidth";
+
 // Components
 import PaginationControl from "../controlls/PaginationControl";
 import { Resizable } from "./subcomponents/Resizable";
@@ -88,6 +91,7 @@ export default function Expanded({
   isSplited,
   isVertical,
 }: Props) {
+  const window = useWindowWidth();
   console.log(layout)
   const [columnWidths, setColumnWidths] = useState({
     studyReviewId: "80px",
@@ -95,8 +99,8 @@ export default function Expanded({
     authors: "95px",
     venue: "110px",
     year: "85px",
-    selectionStatus: "90px",
-    extractionStatus: "90px",
+    selectionStatus: "100px",
+    extractionStatus: "100px",
     score: "70px",
     readingPriority: "80px",
   });
@@ -319,7 +323,7 @@ export default function Expanded({
                       key={col.key}
                       textAlign="center"
                       color="#263C56"
-                      fontSize="medium"
+                      fontSize={window > 1100 ? "medium" : "smaller"}
                       textTransform="capitalize"
                       cursor="pointer"
                       w={columnWidths[col.key]}

--- a/src/features/review/shared/hooks/useVisibilityColumns.ts
+++ b/src/features/review/shared/hooks/useVisibilityColumns.ts
@@ -1,6 +1,9 @@
 // External library
 import { useMemo, useState, useEffect } from "react";
 
+// Hooks
+import useWindowWidth from "@features/shared/hooks/useWindowWidth";
+
 // Types
 import { PageLayout } from "../components/structure/LayoutFactory";
 
@@ -65,6 +68,8 @@ const defaultVisibility: ColumnVisibility = {
 export default function useVisibiltyColumns({
   page,
 }: UseVisibilityColumnsInput): UseVisibilityColumnsOutput {
+  const window = useWindowWidth();
+
   const initialVisibility = useMemo(() => {
     const visibility = { ...defaultVisibility };
     if (page === "Selection") {
@@ -81,6 +86,11 @@ export default function useVisibiltyColumns({
       visibility.studies = null;
       visibility.totalAnswers = null;
       visibility.percentageOfTotal = null;
+      if(window < 1100) {
+        visibility.readingPriority = false;
+        visibility.score = false;
+        visibility.venue = false;
+      }
     }
     if (page === "Extraction") {
       visibility.selectionStatus = null;
@@ -96,6 +106,11 @@ export default function useVisibiltyColumns({
       visibility.studies = null;
       visibility.totalAnswers = null;
       visibility.percentageOfTotal = null;
+      if(window < 1100) {
+        visibility.readingPriority = false;
+        visibility.score = false;
+        visibility.venue = false;
+      }
     }
     if (page === "Identification"){
       visibility.selectionStatus = null;


### PR DESCRIPTION
## Summary

This PR fixes the responsiveness in the Selection/Extraction table. It resizes dinamically the font-size and status column width, and displays only five columns on smaller screens.

## Changes

In the `useVisibiltyColumns` hook, it uses the `useWindowWidth` hook to handle the visible columns depending on the size of the current screen.

On bigger screens the table has 8 columns:

``` bash
ID
Title
Author
Venue
Year
Selection/Extraction status
Score
Priority
```

On smalller screens it has 5 columns:

```bash
ID
Title
Author
Year
Selection/Extraction status
```
It increases the width of the status column and, also using the `useWindowWidth` hook, decreases the font-size of the table header on smaller screens.

## Screenshots

### Small screens

<img width="542" height="721" alt="Captura de tela 2026-07-28 111244" src="https://github.com/user-attachments/assets/0456cd6a-8880-426e-b328-e9a661c74910" />

### Big screens

<img width="1917" height="946" alt="image" src="https://github.com/user-attachments/assets/d4a1a49a-3efe-4f3f-ae70-3304d4bbf496" />
