### PR TITLE
feat(planning-protocol): add deletion guard for eligibility criteria in use

### DIFF
--- a/src/features/review/planning-protocol/components/common/modals/DeleteCriteriaModal/index.tsx
+++ b/src/features/review/planning-protocol/components/common/modals/DeleteCriteriaModal/index.tsx
@@ -1,0 +1,95 @@
+import { useTranslation } from "react-i18next";
+
+import Axios from "../../../../../../../infrastructure/http/axiosClient";
+import DeleteWithValidationModal from "@features/review/shared/components/common/modals/DeleteWithValidationModal";
+
+interface DeleteCriteriaModalProps {
+  criteriaDescription: string;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+interface StudyReviewDto {
+  criteria: string[];
+}
+
+interface PagedResponse {
+  studyReviews: StudyReviewDto[];
+  totalPages: number;
+}
+
+const BLOCKED_STATUSES = ["INCLUDED", "EXCLUDED"];
+
+async function hasStudiesWithStatus(
+  reviewId: string,
+  criteriaDescription: string,
+  selectionStatus: string
+): Promise<boolean> {
+  const size = 50;
+  let page = 0;
+
+  while (true) {
+    const path = `systematic-study/${reviewId}/study-review/search`;
+    const response = await Axios.get<PagedResponse>(path, {
+      params: { page, size, selectionStatus },
+    });
+
+    const studies = response.data?.studyReviews ?? [];
+    const totalPages = response.data?.totalPages ?? 0;
+
+    const found = studies.some((s) =>
+      (s.criteria ?? []).includes(criteriaDescription)
+    );
+
+    if (found) return true;
+    if (page >= totalPages - 1) break;
+    page++;
+  }
+
+  return false;
+}
+
+async function canDeleteCriteria(
+  reviewId: string,
+  criteriaDescription: string
+): Promise<boolean> {
+  for (const status of BLOCKED_STATUSES) {
+    const blocked = await hasStudiesWithStatus(
+      reviewId,
+      criteriaDescription,
+      status
+    );
+    if (blocked) return false;
+  }
+  return true;
+}
+
+export default function DeleteCriteriaModal({
+  criteriaDescription,
+  onConfirm,
+  onClose,
+}: DeleteCriteriaModalProps) {
+  const { t } = useTranslation("review/planning-protocol");
+  const reviewId = localStorage.getItem("systematicReviewId") ?? "";
+
+  return (
+    <DeleteWithValidationModal
+      checkCanDelete={() => canDeleteCriteria(reviewId, criteriaDescription)}
+      onConfirm={async () => onConfirm()}
+      onClose={onClose}
+      labels={{
+        heading: t("deleteCriteriaModal.heading"),
+        confirmMessage: t("deleteCriteriaModal.confirmMessage"),
+        blockedTitle: t("deleteCriteriaModal.blockedTitle"),
+        blockedMessage: t("deleteCriteriaModal.blockedMessage"),
+        checking: t("deleteCriteriaModal.checking"),
+        cancel: t("deleteCriteriaModal.cancel"),
+        confirm: t("deleteCriteriaModal.confirm"),
+        successTitle: t("deleteCriteriaModal.toasts.success.title"),
+        successDescription: t("deleteCriteriaModal.toasts.success.description"),
+        errorTitle: t("deleteCriteriaModal.toasts.catch.title"),
+        errorDescription: t("deleteCriteriaModal.toasts.catch.description"),
+      }}
+    />
+  );
+}

--- a/src/features/review/planning-protocol/components/common/tables/InfosTable/index.tsx
+++ b/src/features/review/planning-protocol/components/common/tables/InfosTable/index.tsx
@@ -8,6 +8,9 @@ import useCreateProtocol from "@features/review/planning-protocol/services/useCr
 import EventButton from "@components/common/buttons/EventButton";
 import useToaster from "@components/feedback/Toaster";
 import { useTranslation } from "react-i18next";
+import DeleteCriteriaModal from "@features/review/planning-protocol/components/common/modals/DeleteCriteriaModal";
+
+const CRITERIA_CONTEXTS = ["Inclusion criteria", "Exclusion criteria"];
 
 interface InfosTableProps {
   AddTexts: string[];
@@ -38,6 +41,7 @@ export default function InfosTable({
   const toaster = useToaster();
   const { t } = useTranslation("review/planning-protocol");
 
+  const [pendingDeleteIndex, setPendingDeleteIndex] = useState<number | null>(null);
   const [newText, setNewText] = useState("");
   const [referenceCode, setReferenceCode] = useState("");
   const [editedCode, setEditedCode] = useState("");
@@ -140,6 +144,7 @@ export default function InfosTable({
   };
 
   return (
+    <>
     <TableContainer
       w="100%"
       sx={{
@@ -228,7 +233,13 @@ export default function InfosTable({
                 <Td textAlign={"right"} py={"1"}>
                   <DeleteButton
                     index={index}
-                    handleDelete={() => onDeleteAddedText(index)}
+                    handleDelete={() => {
+                      if (CRITERIA_CONTEXTS.includes(context)) {
+                        setPendingDeleteIndex(index);
+                      } else {
+                        onDeleteAddedText(index);
+                      }
+                    }}
                   />
                   {typeField !== "select" && (
                     <EditButton
@@ -245,5 +256,17 @@ export default function InfosTable({
         </Tbody>
       </Table>
     </TableContainer>
+
+    {pendingDeleteIndex !== null && CRITERIA_CONTEXTS.includes(context) && (
+      <DeleteCriteriaModal
+        criteriaDescription={AddTexts[pendingDeleteIndex] ?? ""}
+        onConfirm={() => {
+          onDeleteAddedText(pendingDeleteIndex);
+          setPendingDeleteIndex(null);
+        }}
+        onClose={() => setPendingDeleteIndex(null)}
+      />
+    )}
+    </>
   );
 }

--- a/src/locales/en/review/planning-protocol.json
+++ b/src/locales/en/review/planning-protocol.json
@@ -174,7 +174,7 @@
                 "label": "Extraction Questions",
                 "question": "QUESTION",
                 "type": "TYPE",
-                "selectType": "Select type", 
+                "selectType": "Select type",
                 "noDataFound": "No data found",
                 "questionType": {
                     "textual": "textual",
@@ -282,6 +282,25 @@
             "max": "Maximum",
             "close": "Close",
             "save": "Save"
+        }
+    },
+    "deleteCriteriaModal": {
+        "heading": "Delete criterion",
+        "confirmMessage": "Are you sure you want to delete this criterion?",
+        "blockedTitle": "Criterion cannot be deleted",
+        "blockedMessage": "This criterion is applied to Included, Excluded or Duplicated articles. Reset all affected articles to Unclassified before deleting the criterion.",
+        "checking": "Checking criterion usage...",
+        "cancel": "Cancel",
+        "confirm": "Confirm deletion",
+        "toasts": {
+            "success": {
+                "title": "Criterion deleted successfully!",
+                "description": "The criterion has been removed."
+            },
+            "catch": {
+                "title": "Action Failed",
+                "description": "Could not delete the criterion. Please try again."
+            }
         }
     }
 }

--- a/src/locales/pt/review/planning-protocol.json
+++ b/src/locales/pt/review/planning-protocol.json
@@ -283,5 +283,24 @@
             "close": "Fechar",
             "save": "Salvar"
         }
+    },
+    "deleteCriteriaModal": {
+        "heading": "Excluir critério",
+        "confirmMessage": "Tem certeza de que deseja excluir este critério?",
+        "blockedTitle": "Critério não pode ser excluído",
+        "blockedMessage": "Este critério está aplicado a artigos Incluídos, Excluídos ou Duplicados. Redefina todos os artigos afetados para Não Classificado antes de excluir o critério.",
+        "checking": "Verificando uso do critério...",
+        "cancel": "Cancelar",
+        "confirm": "Confirmar exclusão",
+        "toasts": {
+            "success": {
+                "title": "Critério excluído com sucesso!",
+                "description": "O critério foi removido."
+            },
+            "catch": {
+                "title": "Ação Falhou",
+                "description": "Não foi possível excluir o critério. Tente novamente."
+            }
+        }
     }
 }


### PR DESCRIPTION
## Descrição
- Adiciona verificação antes de excluir critérios de inclusão/exclusão no planejamento, seguindo o padrão já existente para fontes de busca e search sessions. Caso o critério esteja aplicado a algum artigo incluído ou excluído, a exclusão é bloqueada com uma mensagem.