### PR TITLE
feat: add support for search by author and journal in tables

### DIFF
--- a/src/features/review/execution-extraction/pages/Extraction/index.tsx
+++ b/src/features/review/execution-extraction/pages/Extraction/index.tsx
@@ -130,7 +130,7 @@ export default function Extraction() {
           />
         </Flex>
         <Box sx={inputconteiner}>
-          <Flex gap=".5rem" w="1rem" justifyContent="space-between" alignItems="center">
+          <Flex gap=".5rem" w="fit-content" justifyContent="space-between" alignItems="center">
             {!isMutipleSelectionEnable && (
               <>
                 <SearchFieldSelect

--- a/src/features/review/execution-extraction/pages/Extraction/index.tsx
+++ b/src/features/review/execution-extraction/pages/Extraction/index.tsx
@@ -22,6 +22,8 @@ import SelectLayout from "../../../shared/components/structure/LayoutButton";
 import ColumnVisibilityMenu from "@features/review/shared/components/common/menu/ColumnVisibilityMenu";
 import StatusSelect from "@features/review/shared/components/common/inputs/StatusSelect";
 import ButtonsForMultipleSelection from "@features/review/shared/components/common/buttons/ButtonsForMultipleSelection";
+import SearchFieldSelect from "@features/review/shared/components/common/inputs/SearchFieldSelect";
+import type { SearchField } from "@features/review/shared/components/common/inputs/SearchFieldSelect";
 
 // Styles
 import { inputconteiner } from "../../../shared/styles/executionStyles";
@@ -41,6 +43,7 @@ export default function Extraction() {
   }, []);
   const [isMutipleSelectionEnable, setIsMultipleSelectionEnable] = useState<boolean>(false);
   const [searchString, setSearchString] = useState<string>("");
+  const [searchField, setSearchField] = useState<SearchField>("title");
   const [showSelected, setShowSelected] = useState<boolean>(false);
   const [fetchedTotalPages, setFetchedTotalPages] = useState<number>(1);
   const selectionContext = useContext(StudySelectionContext);
@@ -85,6 +88,7 @@ export default function Extraction() {
       page: currentPage - 1,
       size: itensPerPage,
       search: searchString,
+      searchField,
       status: selectedStatus,
       sortConfig,
     });
@@ -126,15 +130,25 @@ export default function Extraction() {
           />
         </Flex>
         <Box sx={inputconteiner}>
-          <Box>
+          <Flex gap=".5rem" w="1rem" justifyContent="space-between" alignItems="center">
             {!isMutipleSelectionEnable && (
-              <InputText
-                type="search"
-                placeholder={t("search")}
-                nome="search"
-                onChange={(e) => setSearchString(e.target.value)}
-                value={searchString}
-              />
+              <>
+                <SearchFieldSelect
+                  value={searchField}
+                  onChange={(field) => {
+                    setSearchField(field);
+                    setSearchString("");
+                  }}
+                  namespace="review/execution-extraction"
+                />
+                <InputText
+                  type="search"
+                  placeholder={t("search")}
+                  nome="search"
+                  onChange={(e) => setSearchString(e.target.value)}
+                  value={searchString}
+                />
+              </>
             )}
             {layout !== "article" ? (
               <ButtonsForMultipleSelection
@@ -144,7 +158,7 @@ export default function Extraction() {
                 setIsMultipleSelectionEnable={setIsMultipleSelectionEnable}
               />
             ) : null}
-          </Box>
+          </Flex>
           <Box
             display="flex"
             gap="1rem"

--- a/src/features/review/execution-extraction/services/useFetchExtractionArticles.ts
+++ b/src/features/review/execution-extraction/services/useFetchExtractionArticles.ts
@@ -21,6 +21,7 @@ interface HttpResponse {
 
 interface FetchParams extends Params {
   search?: string;
+  searchField?: "title" | "authors" | "venue";
   status?: string | null;
   sortConfig?: {
     key: keyof ArticleInterface | string;
@@ -41,6 +42,7 @@ const useFetchExtractionArticles = ({
   page = 0,
   size = 20,
   search = "",
+  searchField = "title",
   status = null,
   sortConfig = null,
 }: FetchParams) => {
@@ -55,7 +57,7 @@ const useFetchExtractionArticles = ({
   };
 
   if (search) {
-    queryParams.title = search;
+    queryParams[searchField] = search;
   }
 
   if (status) {

--- a/src/features/review/execution-selection/pages/Selection/index.tsx
+++ b/src/features/review/execution-selection/pages/Selection/index.tsx
@@ -24,6 +24,8 @@ import SelectLayout from "../../../shared/components/structure/LayoutButton";
 import ColumnVisibilityMenu from "@features/review/shared/components/common/menu/ColumnVisibilityMenu";
 import StatusSelect from "@features/review/shared/components/common/inputs/StatusSelect";
 import ButtonsForMultipleSelection from "@features/review/shared/components/common/buttons/ButtonsForMultipleSelection";
+import SearchFieldSelect from "@features/review/shared/components/common/inputs/SearchFieldSelect";
+import type { SearchField } from "@features/review/shared/components/common/inputs/SearchFieldSelect";
 
 import ArticleInterface from "@features/review/shared/types/ArticleInterface";
 
@@ -40,6 +42,7 @@ export default function Selection() {
   }, []);
   const [isMutipleSelectionEnable, setIsMultipleSelectionEnable] = useState<boolean>(false);
   const [searchString, setSearchString] = useState<string>("");
+  const [searchField, setSearchField] = useState<SearchField>("title");
   const [showSelected, setShowSelected] = useState<boolean>(false);
   const [fetchedTotalPages, setFetchedTotalPages] = useState<number>(1);
   const selectionContext = useContext(StudySelectionContext);
@@ -89,6 +92,7 @@ export default function Selection() {
       page: currentPage - 1,
       size: itensPerPage,
       search: searchString,
+      searchField,
       status: selectedStatus,
       sortConfig,
     });
@@ -128,17 +132,26 @@ export default function Selection() {
             handleChangeLayout={handleChangeLayout}
             layout={layout}
           />
-        </Flex>
         <Box sx={inputconteiner}>
-          <Box>
+          <Flex gap=".5rem" w="1rem" justifyContent="space-between" alignItems="center">
             {!isMutipleSelectionEnable && (
-              <InputText
-                type="search"
-                placeholder={t("search")}
-                nome="search"
-                onChange={(e) => setSearchString(e.target.value)}
-                value={searchString}
-              />
+              <>
+                <SearchFieldSelect
+                  value={searchField}
+                  onChange={(field) => {
+                    setSearchField(field);
+                    setSearchString("");
+                  }}
+                  namespace="review/execution-selection"
+                />
+                <InputText
+                  type="search"
+                  placeholder={t("search")}
+                  nome="search"
+                  onChange={(e) => setSearchString(e.target.value)}
+                  value={searchString}
+                />
+              </>
             )}
             {layout !== "article" ? (
               <ButtonsForMultipleSelection
@@ -148,7 +161,7 @@ export default function Selection() {
                 setIsMultipleSelectionEnable={setIsMultipleSelectionEnable}
               />
             ) : null}
-          </Box>
+          </Flex>
           <Box
             display="flex"
             gap="1rem"

--- a/src/features/review/execution-selection/pages/Selection/index.tsx
+++ b/src/features/review/execution-selection/pages/Selection/index.tsx
@@ -132,8 +132,9 @@ export default function Selection() {
             handleChangeLayout={handleChangeLayout}
             layout={layout}
           />
+        </Flex>
         <Box sx={inputconteiner}>
-          <Flex gap=".5rem" w="1rem" justifyContent="space-between" alignItems="center">
+          <Flex gap=".5rem" w="fit-content" justifyContent="space-between" alignItems="center">
             {!isMutipleSelectionEnable && (
               <>
                 <SearchFieldSelect
@@ -165,8 +166,9 @@ export default function Selection() {
           <Box
             display="flex"
             gap="1rem"
-            justifyContent="space-between"
+            justifyContent={{ base: "center", md: "flex-start", lg: "space-between" }}
             alignItems="center"
+            ml={{ base: "0%", md: "-35%", lg: "0%" }}
           >
             <ColumnVisibilityMenu
               columnsVisible={columnsVisible}

--- a/src/features/review/execution-selection/services/useFetchSelectionArticles.ts
+++ b/src/features/review/execution-selection/services/useFetchSelectionArticles.ts
@@ -21,6 +21,7 @@ export interface SelectionArticles {
 
 interface FetchParams extends Params {
   search?: string;
+  searchField?: "title" | "authors" | "venue";
   status?: string | null;
   // NOVO: Adicionado o sortConfig na tipagem dos parâmetros
   sortConfig?: {
@@ -42,6 +43,7 @@ const useFetchSelectionArticles = ({
   page = 0,
   size = 20,
   search = "",
+  searchField = "title",
   status = null,
   sortConfig = null,
 }: FetchParams) => {
@@ -54,7 +56,7 @@ const useFetchSelectionArticles = ({
   };
 
   if (search) {
-    queryParams.title = search;
+    queryParams[searchField] = search;
   }
 
   if (status) {

--- a/src/features/review/shared/components/common/inputs/SearchFieldSelect/index.tsx
+++ b/src/features/review/shared/components/common/inputs/SearchFieldSelect/index.tsx
@@ -1,0 +1,45 @@
+// External library
+import { Select, FormControl } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+
+export type SearchField = "title" | "authors" | "venue";
+
+interface SearchFieldSelectProps {
+  value: SearchField;
+  onChange: (field: SearchField) => void;
+  namespace: "review/execution-selection" | "review/execution-extraction";
+}
+
+export default function SearchFieldSelect({
+  value,
+  onChange,
+  namespace,
+}: SearchFieldSelectProps) {
+  const { t } = useTranslation(namespace);
+
+  const options: { value: SearchField; labelKey: string }[] = [
+    { value: "title", labelKey: "searchField.title" },
+    { value: "authors", labelKey: "searchField.authors" },
+    { value: "venue", labelKey: "searchField.venue" },
+  ];
+
+  return (
+    <FormControl w="10rem" flexShrink={0}>
+      <Select
+        bgColor="#EBF0F3"
+        color="#2E4B6C"
+        fontWeight="medium"
+        value={value}
+        onChange={(e) => onChange(e.target.value as SearchField)}
+        borderRadius="md"
+        size="md"
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {t(opt.labelKey)}
+          </option>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}

--- a/src/features/review/shared/components/common/inputs/SearchFieldSelect/index.tsx
+++ b/src/features/review/shared/components/common/inputs/SearchFieldSelect/index.tsx
@@ -1,6 +1,7 @@
 // External library
-import { Select, FormControl } from "@chakra-ui/react";
+import { Menu, MenuButton, MenuList, MenuItem, IconButton, Tooltip, FormControl } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { BsSliders } from "react-icons/bs";
 
 export type SearchField = "title" | "authors" | "venue";
 
@@ -24,22 +25,35 @@ export default function SearchFieldSelect({
   ];
 
   return (
-    <FormControl w="10rem" flexShrink={0}>
-      <Select
-        bgColor="#EBF0F3"
-        color="#2E4B6C"
-        fontWeight="medium"
-        value={value}
-        onChange={(e) => onChange(e.target.value as SearchField)}
-        borderRadius="md"
-        size="md"
-      >
-        {options.map((opt) => (
-          <option key={opt.value} value={opt.value}>
-            {t(opt.labelKey)}
-          </option>
-        ))}
-      </Select>
+    <FormControl w="auto" flexShrink={0}>
+      <Menu isLazy>
+        <Tooltip label={t("searchFieldTooltip")} aria-label={t("searchFieldTooltip")} hasArrow>
+          <MenuButton
+            as={IconButton}
+            aria-label={t("searchFieldTooltip")}
+            icon={<BsSliders size="1.2rem" />}
+            bgColor="#EBF0F3"
+            color="#2E4B6C"
+            borderRadius="md"
+            size="md"
+            _hover={{ bgColor: "#D3DCE3" }}
+            _active={{ bgColor: "#C4CFD8" }}
+          />
+        </Tooltip>
+        <MenuList zIndex={1400}>
+          {options.map((opt) => (
+            <MenuItem
+              key={opt.value}
+              onClick={() => onChange(opt.value)}
+              fontWeight={value === opt.value ? "bold" : "normal"}
+              bgColor={value === opt.value ? "#EBF0F3" : "transparent"}
+              _hover={{ bgColor: "#D3DCE3" }}
+            >
+              {t(opt.labelKey)}
+            </MenuItem>
+          ))}
+        </MenuList>
+      </Menu>
     </FormControl>
   );
 }

--- a/src/locales/en/review/execution-extraction.json
+++ b/src/locales/en/review/execution-extraction.json
@@ -1,6 +1,7 @@
 {
     "header": "Extraction",
-    "search": "Search by title, author or journal",
+    "search": "Search article",
+    "searchFieldTooltip": "Search by title, author or journal",
     "searchField": {
         "title": "Title",
         "authors": "Author",

--- a/src/locales/en/review/execution-extraction.json
+++ b/src/locales/en/review/execution-extraction.json
@@ -1,6 +1,11 @@
 {
     "header": "Extraction",
-    "search": "Insert article attribute",
+    "search": "Search by title, author or journal",
+    "searchField": {
+        "title": "Title",
+        "authors": "Author",
+        "venue": "Journal"
+    },
     "extractionFormDisabled": {
         "title": "Extraction Disabled",
         "text1": "This study is currently marked as",

--- a/src/locales/en/review/execution-selection.json
+++ b/src/locales/en/review/execution-selection.json
@@ -11,7 +11,12 @@
             "article": "article"
         }
     },
-    "search": "Insert article attribute",
+    "search": "Search by title, author or journal",
+    "searchField": {
+        "title": "Title",
+        "authors": "Author",
+        "venue": "Journal"
+    },
     "buttonsForMultipleSelection": {
         "showSelected": "Show selected",
         "showAll": "Show all",

--- a/src/locales/en/review/execution-selection.json
+++ b/src/locales/en/review/execution-selection.json
@@ -11,7 +11,8 @@
             "article": "article"
         }
     },
-    "search": "Search by title, author or journal",
+    "search": "Search article",
+    "searchFieldTooltip": "Search by title, author or journal",
     "searchField": {
         "title": "Title",
         "authors": "Author",

--- a/src/locales/pt/review/execution-extraction.json
+++ b/src/locales/pt/review/execution-extraction.json
@@ -1,6 +1,11 @@
 {
     "header": "Extração",
-    "search": "Inserir atributo do artigo",
+    "search": "Buscar por título, autor ou periódico",
+    "searchField": {
+        "title": "Título",
+        "authors": "Autor",
+        "venue": "Periódico"
+    },
     "extractionFormDisabled": {
         "title": "Extração Desabilitada",
         "text1": "Esse estudo está marcado como",

--- a/src/locales/pt/review/execution-extraction.json
+++ b/src/locales/pt/review/execution-extraction.json
@@ -1,6 +1,7 @@
 {
     "header": "Extração",
-    "search": "Buscar por título, autor ou periódico",
+    "search": "Buscar artigo",
+    "searchFieldTooltip": "Pesquisar por título, autor ou periódico",
     "searchField": {
         "title": "Título",
         "authors": "Autor",

--- a/src/locales/pt/review/execution-selection.json
+++ b/src/locales/pt/review/execution-selection.json
@@ -11,7 +11,12 @@
             "article": "artigo"
         }
     },
-    "search": "Inserir atributo do artigo",
+    "search": "Buscar por título, autor ou periódico",
+    "searchField": {
+        "title": "Título",
+        "authors": "Autor",
+        "venue": "Periódico"
+    },
     "buttonsForMultipleSelection": {
         "showSelected": "Mostrar selecionados",
         "showAll": "Mostrar todos",

--- a/src/locales/pt/review/execution-selection.json
+++ b/src/locales/pt/review/execution-selection.json
@@ -11,7 +11,8 @@
             "article": "artigo"
         }
     },
-    "search": "Buscar por título, autor ou periódico",
+    "search": "Buscar artigo",
+    "searchFieldTooltip": "Pesquisar por título, autor ou periódico",
     "searchField": {
         "title": "Título",
         "authors": "Autor",


### PR DESCRIPTION
Summary
This PR introduces the ability to search for articles by author name or journal (venue) in addition to the title across both the Selection and Extraction pages. Since the backend applies an AND operator when multiple search parameters are sent, this is solved on the frontend by introducing a search field selector dropdown, allowing users to dynamically choose the target field they want to query.

Changes
1. feat: add search field selector component
- SearchFieldSelect/index.tsx [NEW]: Created a reusable dropdown component using Chakra UI for selecting the search criteria ("Title", "Author", or "Journal").
2. feat: support dynamic search fields in fetch hooks
- useFetchSelectionArticles.ts & useFetchExtractionArticles.ts: Updated the hooks to accept a `searchField` parameter. Instead of hardcoding the search query to `title`, it maps it dynamically to `title`, `authors`, or `venue` query parameters depending on the selection.
3. feat: integrate the field selector in Selection and Extraction layouts
- Selection/index.tsx & Extraction/index.tsx: Integrated the `SearchFieldSelect` component next to the search input, ensuring it resets the search string on change and respects multiple selection visibility states.


Why
Previously, the search input was restricted to article titles only. This change provides researchers with the flexibility to quickly locate specific studies by their authors or publication venues during both the Selection and Extraction phases. Using a dropdown selector ensures that only one search parameter is queried at a time, preventing empty search results that would occur if multiple search fields were sent concurrently due to the backend's AND combination logic.