### PR TITLE
feat(collaborators): integrate researcher addition component with backend and add invitation acceptance flow

### DIFF
--- a/src/features/review/join-review/pages/index.tsx
+++ b/src/features/review/join-review/pages/index.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import useToaster from "@components/feedback/Toaster";
+import { isLeft } from "@features/shared/errors/pattern/Either";
+import respondInvitation from "../services/respondInvitation";
+
+export default function JoinReview() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const toast = useToaster();
+  const { t } = useTranslation("landing/email-pages");
+
+  useEffect(() => {
+    const token = searchParams.get("token")?.trim();
+
+    if (!token) {
+      toast({
+        title: t("joinReview.toast.emptyTokenTitle"),
+        description: t("joinReview.toast.emptyTokenDesc"),
+        status: "error",
+      });
+      setTimeout(() => navigate("/"), 3000);
+      return;
+    }
+
+    const handleAccept = async () => {
+      const result = await respondInvitation({
+        token,
+        inviteResponse: "ACCEPTED",
+      });
+
+      if (isLeft(result)) {
+        toast({
+          title: t("joinReview.toast.errorTitle"),
+          description: t("joinReview.toast.errorDesc"),
+          status: "error",
+        });
+      } else {
+        toast({
+          title: t("joinReview.toast.successTitle"),
+          description: t("joinReview.toast.successDesc"),
+          status: "success",
+        });
+      }
+
+      setTimeout(() => navigate("/home"), 3000);
+    };
+
+    handleAccept();
+  }, [searchParams, navigate, toast, t]);
+
+  return <p>{t("joinReview.loading")}</p>;
+}

--- a/src/features/review/join-review/services/respondInvitation.ts
+++ b/src/features/review/join-review/services/respondInvitation.ts
@@ -1,0 +1,41 @@
+// External library
+import { isAxiosError } from "axios";
+
+// Infra
+import Axios from "../../../../infrastructure/http/axiosClient";
+
+// Factory
+import errorFactory from "@features/shared/errors/factory/errorFactory";
+
+// Error
+import { type Either, right } from "@features/shared/errors/pattern/Either";
+import { ApplicationError } from "@features/shared/errors/base/ApplicationError";
+
+type InviteResponse = "ACCEPTED" | "REJECTED";
+
+type Payload = {
+  token: string;
+  inviteResponse: InviteResponse;
+};
+
+export default async function respondInvitation(
+  data: Payload
+): Promise<Either<ApplicationError, Response>> {
+  try {
+    const { data: response } = await Axios.post(
+      "systematic-study/respond-invitation",
+      data
+    );
+    return right(response);
+  } catch (error) {
+    if (isAxiosError(error)) {
+      return errorFactory("unauthorized", error.message);
+    }
+
+    if (error instanceof Error) {
+      return errorFactory("custom", error.message);
+    }
+
+    return errorFactory("custom", "An unexpected error occurred.");
+  }
+}

--- a/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/AddResearcher.tsx
+++ b/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/AddResearcher.tsx
@@ -1,135 +1,172 @@
 import { useTranslation } from "react-i18next";
 import { Flex, Input, Box, Avatar, Text } from "@chakra-ui/react";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import EventButton from "@components/common/buttons/EventButton";
+import useToaster from "@components/feedback/Toaster";
+import {
+  searchCollaboratorCandidates,
+  type CollaboratorCandidate,
+} from "./services/searchCollaboratorCandidates";
+import { inviteCollaborator } from "./services/useInviteCollaborator";
+import type { Researcher } from "./services/useFetchCollaborators";
 
-export default function AddResearcher({researchers, setResearchers}:any) {
-  const { t } = useTranslation("review/planning-protocol"); 
-  // Backend
-  function filterSearch(search: string){
-    return function (researcher:any){
-      const fullResearcherReference = `${researcher.name} - ${researcher.email}`;
-      return (fullResearcherReference.toLowerCase().includes(search.toLowerCase()));
-    }
-  }
+interface Props {
+  researchers: Researcher[];
+  setResearchers: (r: Researcher[]) => void;
+  systematicStudyId: string;
+}
 
-  function filterStatus(status: string){
-    return function (researcher:any){
-      return (researcher.status === status);
-    }
-  }
+const SEARCH_TRIGGER_STEP = 3;
 
-  function filterSearchAndStatus({ search, status }: { search?: string; status?: string }) {
-    let result = researchers;
-  
-    if (status) {
-      result = result.filter(filterStatus(status));
-    }
-  
-    if (search) {
-      result = result.filter(filterSearch(search));
-    }
-  
-    return result;
-  }
-
-  function inviteResearcher(id: string){
-    setResearchers(researchers.map((researcher:any) => {
-      if(researcher.id == id){
-        return { ...researcher, status: "pending" };
-      }
-      else{
-        return researcher;
-      }
-    }))
-  }
-
-  const SEARCH_TRIGGER_STEP = 3;
+export default function AddResearcher({
+  researchers,
+  setResearchers,
+  systematicStudyId,
+}: Props) {
+  const { t } = useTranslation("review/planning-protocol");
+  const toast = useToaster();
 
   const [search, setSearch] = useState("");
-  const [potentialResearchers, setPotentialResearchers] = useState(() => filterSearchAndStatus({ status: "none" }));
+  const [candidates, setCandidates] = useState<CollaboratorCandidate[]>([]);
   const [suggestionsOpen, setSuggestionsOpen] = useState(false);
-  const [chosenResearcherId, setChosenResearcherId] = useState("");
+  const [chosenCandidate, setChosenCandidate] = useState<CollaboratorCandidate | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
   const inputRef = useRef<HTMLInputElement>(null);
   const lastTriggeredLengthRef = useRef(0);
 
-  useEffect(() => {
-    setPotentialResearchers(filterSearchAndStatus({ status: "none" }));
-  }, [researchers]);
+  const alreadyAddedIds = new Set(researchers.map((r) => r.id));
+  const filteredCandidates = candidates.filter((c) => !alreadyAddedIds.has(c.id));
 
-  const handleAddResearcher = () => {
-    inviteResearcher(chosenResearcherId);
+  async function fetchCandidates(prefix: string) {
+    if (!systematicStudyId || prefix.length < SEARCH_TRIGGER_STEP) return;
+    try {
+      const results = await searchCollaboratorCandidates({ systematicStudyId, prefix });
+      setCandidates(results);
+    } catch {
+      setCandidates([]);
+    }
+  }
 
-    // Reset all states
-    setChosenResearcherId("");
-    setSearch("");
-    setSuggestionsOpen(false);
-    lastTriggeredLengthRef.current = 0;
-  };
-
-  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>){
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
     const value = e.target.value;
     setSearch(value);
-    setChosenResearcherId("");
+    setChosenCandidate(null);
 
     if (Math.abs(value.length - lastTriggeredLengthRef.current) >= SEARCH_TRIGGER_STEP) {
-      setPotentialResearchers(filterSearchAndStatus({ search: value, status: "none" }));
+      fetchCandidates(value);
       lastTriggeredLengthRef.current = value.length;
+    }
+  }
+
+  async function handleAddResearcher() {
+    if (!chosenCandidate || isLoading) return;
+    setIsLoading(true);
+
+    try {
+      const invited = await inviteCollaborator({
+        systematicStudyId,
+        usernameCollaborator: chosenCandidate.username,
+      });
+
+      const newResearcher: Researcher = {
+        id: chosenCandidate.id,
+        name: invited.collaboratorUsername,
+        email: invited.collaboratorEmail,
+        role: "reviewer",
+        status: "pending",
+      };
+
+      setResearchers([...researchers, newResearcher]);
+
+      toast({
+        title: t("generalDefinition.input.researchers.toasts.inviteSent.title"),
+        description: `${t("generalDefinition.input.researchers.toasts.inviteSent.description")} ${invited.collaboratorUsername}.`,
+        status: "success",
+      });
+    } catch {
+      toast({
+        title: t("generalDefinition.input.researchers.toasts.inviteError.title"),
+        description: t("generalDefinition.input.researchers.toasts.inviteError.description"),
+        status: "error",
+      });
+    } finally {
+      setChosenCandidate(null);
+      setSearch("");
+      setSuggestionsOpen(false);
+      setCandidates([]);
+      lastTriggeredLengthRef.current = 0;
+      setIsLoading(false);
     }
   }
 
   return (
     <Flex justify="center" py={2}>
       <Flex gap={2} align="center" width="28rem" position="relative">
-
         <Input
           ref={inputRef}
-          style = {{ backgroundColor: chosenResearcherId !== "" ? "#C9D9E5" : "#ffffffff" }} flex="1" minW={0} size="md"  
-          value={search} 
-          placeholder={t("generalDefinition.input.researchers.placeholder")} 
-          onChange = {handleInputChange} 
+          style={{ backgroundColor: chosenCandidate ? "#C9D9E5" : "#ffffffff" }}
+          flex="1"
+          minW={0}
+          size="md"
+          value={search}
+          placeholder={t("generalDefinition.input.researchers.placeholder")}
+          onChange={handleInputChange}
           onFocus={() => setSuggestionsOpen(true)}
           onBlur={() => setSuggestionsOpen(false)}
         />
-        
-        {suggestionsOpen && (
-            <Box position="absolute" width="25rem" top="100%" mt={1} bg="white" border="1px solid" borderColor="gray.300" borderRadius="md">
-              {potentialResearchers.length > 0 ? (
-                potentialResearchers.slice(0, 3).map((researcher:any) => (
-                    <Flex
-                      key={researcher.id}
-                      align="center"
-                      gap={3}
-                      px={3}
-                      py={2}
-                      cursor="pointer"
-                      _hover={{ bg: "gray.100" }}
-                      onMouseDown={(e) => e.preventDefault()}
-                      onClick={() => {
-                        setSearch(`${researcher.name} - ${researcher.email}`);
-                        setChosenResearcherId(researcher.id);
-                        inputRef.current?.blur();
-                      }}
-                    >
-                      <Avatar size="sm" name={researcher.name} bg="#2E4B6C" color="white" />
-                      <Text flex="1" fontSize="sm">{researcher.name} - {researcher.email}</Text>
-                    </Flex>
-                  ))
-                ) : (
-                  <Text color="gray.500" textAlign="center">{t("generalDefinition.input.researchers.noResearchersFound")}</Text>
-                )
-            }
-        </Box>
+
+        {suggestionsOpen && search.length >= SEARCH_TRIGGER_STEP && (
+          <Box
+            position="absolute"
+            width="25rem"
+            top="100%"
+            mt={1}
+            bg="white"
+            border="1px solid"
+            borderColor="gray.300"
+            borderRadius="md"
+            zIndex={10}
+          >
+            {filteredCandidates.length > 0 ? (
+              filteredCandidates.slice(0, 3).map((candidate) => (
+                <Flex
+                  key={candidate.id}
+                  align="center"
+                  gap={3}
+                  px={3}
+                  py={2}
+                  cursor="pointer"
+                  _hover={{ bg: "gray.100" }}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => {
+                    setSearch(`${candidate.username} - ${candidate.email}`);
+                    setChosenCandidate(candidate);
+                    inputRef.current?.blur();
+                  }}
+                >
+                  <Avatar size="sm" name={candidate.username} bg="#2E4B6C" color="white" />
+                  <Text flex="1" fontSize="sm">
+                    {candidate.username} - {candidate.email}
+                  </Text>
+                </Flex>
+              ))
+            ) : (
+              <Text color="gray.500" textAlign="center" p={2}>
+                {t("generalDefinition.input.researchers.noResearchersFound")}
+              </Text>
+            )}
+          </Box>
         )}
 
         <EventButton
-          style={{opacity: chosenResearcherId !== "" ? 1 : 0.30}}
+          style={{ opacity: chosenCandidate && !isLoading ? 1 : 0.3 }}
           w="40px"
           flexShrink={0}
-          onClick={chosenResearcherId !== "" ? handleAddResearcher : undefined}
-          disabled={chosenResearcherId === ""}
+          onClick={chosenCandidate && !isLoading ? handleAddResearcher : undefined}
+          disabled={!chosenCandidate || isLoading}
         />
       </Flex>
     </Flex>
-  )
+  );
 }

--- a/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/IncludedResearchers.tsx
+++ b/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/IncludedResearchers.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { ChevronDownIcon, EditIcon, DeleteIcon } from "@chakra-ui/icons";
-import { Avatar,
+import {
+  Avatar,
   Button,
   Flex,
   Icon,
@@ -17,109 +18,141 @@ import { Avatar,
   AlertDialogOverlay,
 } from "@chakra-ui/react";
 import { useState, useEffect, useRef } from "react";
+import useToaster from "@components/feedback/Toaster";
+import { removeCollaborator } from "./services/useRemoveCollaborator";
+import { updateResearcherRole } from "./services/useUpdateResearcherRole";
+import type { Researcher } from "./services/useFetchCollaborators";
 
-const AVAILABLE_ROLES = ["admin", "reviewer", "owner"] as const;
+interface Props {
+  researchers: Researcher[];
+  setResearchers: (r: Researcher[]) => void;
+  systematicStudyId: string;
+}
 
-export default function IncludedResearchers({researchers, setResearchers}:any) {
-  const { t } = useTranslation("review/planning-protocol"); 
+const AVAILABLE_ROLES = ["viewer", "reviewer", "editor", "admin"] as const;
+type Role = (typeof AVAILABLE_ROLES)[number];
 
-  const [researcherToDelete, setResearcherToDelete] = useState<any>(null);
-  
+export default function IncludedResearchers({
+  researchers,
+  setResearchers,
+  systematicStudyId,
+}: Props) {
+  const { t } = useTranslation("review/planning-protocol");
+  const toast = useToaster();
   const cancelRef = useRef<HTMLButtonElement>(null!);
 
-  // Backend
-  function filterSearch(search: string){
-    return function (researcher:any){
-      const fullResearcherReference = `${researcher.name} - ${researcher.email}`;
-      return (fullResearcherReference.toLowerCase().includes(search.toLowerCase()));
-    }
-  }
-
-  function filterStatus(status: string){
-    return function (researcher:any){
-      return (researcher.status === status);
-    }
-  }
-
-  function filterSearchAndStatus({ search, status }: { search?: string; status?: string }) {
-    let result = researchers;
-  
-    if (status) {
-      result = result.filter(filterStatus(status));
-    }
-  
-    if (search) {
-      result = result.filter(filterSearch(search));
-    }
-  
-    return result;
-  }
-
-  function excludeResearcher(id: string){
-    setResearchers(researchers.map((researcher:any) => {
-      if(researcher.id == id){
-        return { ...researcher, status: "none" };
-      }
-      else{
-        return researcher;
-      }
-    }))
-  }
-
-  function changeRole(id: string, role: string){
-    setResearchers(researchers.map((researcher:any) => {
-      if(researcher.id == id){
-        return { ...researcher, role };
-      }
-      else{
-        return researcher;
-      }
-    }))
-  }
-
-  const [listedResearchers, setListedResearchers] = useState(() => [
-    ...filterSearchAndStatus({ status: "pending" }),
-    ...filterSearchAndStatus({ status: "expired" }),
-    ...filterSearchAndStatus({ status: "included" }),
-  ]);
-
+  const [researcherToDelete, setResearcherToDelete] = useState<Researcher | null>(null);
+  const [isDeletingIncluded, setIsDeletingIncluded] = useState(false);
   const [editingResearcherId, setEditingResearcherId] = useState<string | null>(null);
-  const [editingRole, setEditingRole] = useState("");
+  const [editingRole, setEditingRole] = useState<Role>("reviewer");
+  const [isSavingRole, setIsSavingRole] = useState(false);
 
-  function handleSaveRole() {
-    if (!editingResearcherId || !editingRole) return;
-
-    changeRole(editingResearcherId, editingRole);
-
-    setEditingResearcherId(null);
-    setEditingRole("");
-  }
-
-  const handleDelete = () => {
-    if (!researcherToDelete) return;
-
-    excludeResearcher(researcherToDelete.id);
-
-    setResearcherToDelete(null);
-  }
+  const [listedResearchers, setListedResearchers] = useState<Researcher[]>([]);
 
   useEffect(() => {
     setListedResearchers([
-      ...filterSearchAndStatus({ status: "pending" }),
-      ...filterSearchAndStatus({ status: "expired" }),
-      ...filterSearchAndStatus({ status: "included" }),
+      ...researchers.filter((r) => r.status === "pending"),
+      ...researchers.filter((r) => r.status === "expired"),
+      ...researchers.filter((r) => r.status === "included"),
     ]);
   }, [researchers]);
 
+  async function handleDelete() {
+    if (!researcherToDelete) return;
+
+    if (researcherToDelete.status === "included") {
+      setIsDeletingIncluded(true);
+      try {
+        await removeCollaborator({
+          systematicStudyId,
+          researcherId: researcherToDelete.id,
+        });
+      } catch {
+        toast({
+          title: t("generalDefinition.input.researchers.toasts.removeError.title"),
+          description: t("generalDefinition.input.researchers.toasts.removeError.description"),
+          status: "error",
+        });
+        setIsDeletingIncluded(false);
+        setResearcherToDelete(null);
+        return;
+      }
+      setIsDeletingIncluded(false);
+    }
+
+    setResearchers(researchers.filter((r) => r.id !== researcherToDelete.id));
+    setResearcherToDelete(null);
+  }
+
+  async function handleSaveRole() {
+    if (!editingResearcherId || !editingRole || isSavingRole) return;
+    setIsSavingRole(true);
+
+    try {
+      await updateResearcherRole({
+        systematicStudyId,
+        researcherId: editingResearcherId,
+        role: editingRole,
+      });
+
+      setResearchers(
+        researchers.map((r) =>
+          r.id === editingResearcherId ? { ...r, role: editingRole } : r
+        )
+      );
+
+      toast({
+        title: t("generalDefinition.input.researchers.toasts.roleUpdated.title"),
+        status: "success",
+      });
+    } catch {
+      toast({
+        title: t("generalDefinition.input.researchers.toasts.roleUpdateError.title"),
+        description: t("generalDefinition.input.researchers.toasts.roleUpdateError.description"),
+        status: "error",
+      });
+    } finally {
+      setEditingResearcherId(null);
+      setEditingRole("reviewer");
+      setIsSavingRole(false);
+    }
+  }
+
   return (
     <>
-      {listedResearchers.map((researcher:any) => (
-        <Flex key={researcher.id} align="center" gap={5} px={4} py={2} borderWidth="1px" borderColor="gray.200" borderRadius="md">
-          <Avatar size="sm" name={researcher.name} bg="#2E4B6C" color="white"/>
-          <Flex align={{ base: "flex-start", xl: "center" }} justify="space-between" flex="1" direction={{ base: "column", xl: "row" }} gap={{ base: 2, xl: 0 }}>
-            <Text wordBreak="break-word" pr={{ base: 0, xl: 4 }}>{researcher.name} - {researcher.email}</Text>
-            <Flex alignItems="center" justifyContent={{ base: "space-between", xl: "flex-end" }} gap={5} w={{ base: "100%", xl: "auto" }}>
-              {(researcher.status === "pending" || researcher.status === "expired" || researcher.status === "excluding") && (
+      {listedResearchers.map((researcher) => (
+        <Flex
+          key={researcher.id}
+          align="center"
+          gap={5}
+          px={4}
+          py={2}
+          borderWidth="1px"
+          borderColor="gray.200"
+          borderRadius="md"
+        >
+          <Avatar size="sm" name={researcher.name} bg="#2E4B6C" color="white" />
+
+          <Flex
+            align={{ base: "flex-start", xl: "center" }}
+            justify="space-between"
+            flex="1"
+            direction={{ base: "column", xl: "row" }}
+            gap={{ base: 2, xl: 0 }}
+          >
+            <Text wordBreak="break-word" pr={{ base: 0, xl: 4 }}>
+              {researcher.name} - {researcher.email}
+            </Text>
+
+            <Flex
+              alignItems="center"
+              justifyContent={{ base: "space-between", xl: "flex-end" }}
+              gap={5}
+              w={{ base: "100%", xl: "auto" }}
+            >
+              {(researcher.status === "pending" ||
+                researcher.status === "expired" ||
+                (researcher.status as string) === "excluding") && (
                 <Text color="gray.500">
                   {t(`generalDefinition.input.researchers.status.${researcher.status}`)}
                 </Text>
@@ -132,7 +165,7 @@ export default function IncludedResearchers({researchers, setResearchers}:any) {
                         as={Button}
                         variant="ghost"
                         size="sm"
-                        rightIcon={<ChevronDownIcon w={18} h={18}/>}
+                        rightIcon={<ChevronDownIcon w={18} h={18} />}
                         fontWeight="normal"
                         fontSize={16}
                         h="100%"
@@ -146,60 +179,69 @@ export default function IncludedResearchers({researchers, setResearchers}:any) {
                         borderInline="3px solid transparent"
                         outline="1px solid black"
                       >
-                        {`${t("generalDefinition.input.researchers.role.role")}: ${t(`generalDefinition.input.researchers.role.${editingRole}`)}`}
+                        {`${t("generalDefinition.input.researchers.role.role")}: ${t(
+                          `generalDefinition.input.researchers.role.${editingRole}`
+                        )}`}
                       </MenuButton>
                       <MenuList>
                         {AVAILABLE_ROLES.map((role) => (
-                          <MenuItem
-                            key={role}
-                            onClick={() => setEditingRole(role)}
-                          >
+                          <MenuItem key={role} onClick={() => setEditingRole(role)}>
                             {t(`generalDefinition.input.researchers.role.${role}`)}
                           </MenuItem>
                         ))}
                       </MenuList>
                     </Menu>
                   ) : (
-                    <Text w={{ base: "auto", xl: "200px" }} h="100%" borderInline="3px solid transparent" p={0} display="flex" alignItems="center" lineHeight="20px">
-                      {`${t("generalDefinition.input.researchers.role.role")}: ${t(`generalDefinition.input.researchers.role.${researcher.role}`)}`}
+                    <Text
+                      w={{ base: "auto", xl: "200px" }}
+                      h="100%"
+                      borderInline="3px solid transparent"
+                      p={0}
+                      display="flex"
+                      alignItems="center"
+                      lineHeight="20px"
+                    >
+                      {`${t("generalDefinition.input.researchers.role.role")}: ${t(
+                        `generalDefinition.input.researchers.role.${researcher.role}`
+                      )}`}
                     </Text>
                   )}
                   <Flex>
                     <Button
                       variant="ghost"
+                      isLoading={isSavingRole && editingResearcherId === researcher.id}
                       onClick={() => {
-                        if(editingResearcherId === researcher.id) {
+                        if (editingResearcherId === researcher.id) {
                           handleSaveRole();
                         } else {
                           setEditingResearcherId(researcher.id);
-                          setEditingRole(researcher.role);
+                          setEditingRole(researcher.role as Role);
                         }
                       }}
                     >
                       {editingResearcherId === researcher.id ? (
-                        <i className="pi pi-save" style={{ color: "black", width: "15px", height: "15px" }}></i>
+                        <i
+                          className="pi pi-save"
+                          style={{ color: "black", width: "15px", height: "15px" }}
+                        />
                       ) : (
-                        <Icon as={EditIcon} w="15px" h="15px"/>
+                        <Icon as={EditIcon} w="15px" h="15px" />
                       )}
                     </Button>
                     <Button
                       variant="ghost"
-                      onClick={() =>
-                        setResearcherToDelete(researcher)
-                      }
+                      onClick={() => setResearcherToDelete(researcher)}
                     >
-                      <Icon as={DeleteIcon} w="15px" h="15px"/>
+                      <Icon as={DeleteIcon} w="15px" h="15px" />
                     </Button>
                   </Flex>
                 </>
               ) : (
                 <Button
                   variant="ghost"
-                  onClick={() =>
-                    setResearcherToDelete(researcher)
-                  }
+                  onClick={() => setResearcherToDelete(researcher)}
                 >
-                  <Icon as={DeleteIcon} w="15px" h="15px"/>
+                  <Icon as={DeleteIcon} w="15px" h="15px" />
                 </Button>
               )}
             </Flex>
@@ -219,23 +261,17 @@ export default function IncludedResearchers({researchers, setResearchers}:any) {
 
             <AlertDialogBody color="#2E4B6C">
               {`${t("generalDefinition.input.researchers.confirm.body")} `}
-              <strong>
-                {researcherToDelete?.name}
-              </strong>
-              ?
+              <strong>{researcherToDelete?.name}</strong>?
             </AlertDialogBody>
 
             <AlertDialogFooter>
-              <Button
-                ref={cancelRef}
-                onClick={() => setResearcherToDelete(null)}
-              >
+              <Button ref={cancelRef} onClick={() => setResearcherToDelete(null)}>
                 {t("generalDefinition.input.researchers.confirm.cancel")}
               </Button>
-
               <Button
                 colorScheme="red"
                 onClick={handleDelete}
+                isLoading={isDeletingIncluded}
                 ml={3}
               >
                 {t("generalDefinition.input.researchers.confirm.delete")}

--- a/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/index.tsx
+++ b/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/index.tsx
@@ -2,20 +2,36 @@ import { useTranslation } from "react-i18next";
 import { Text, VStack } from "@chakra-ui/react";
 import AddResearcher from "./AddResearcher";
 import IncludedResearchers from "./IncludedResearchers";
-import {useState} from 'react';
-import { researchersMock } from "../../../../../../../mocks/researchers";
+import { useState, useEffect } from "react";
+import useToaster from "@components/feedback/Toaster";
+import { fetchCollaborators, type Researcher } from "./services/useFetchCollaborators";
 
 export default function ResearcherFilter() {
-  const [researchers, setResearchers] = useState(researchersMock)
-  const { t } = useTranslation("review/planning-protocol"); 
+  const [researchers, setResearchers] = useState<Researcher[]>([]);
+  const { t } = useTranslation("review/planning-protocol");
+  const toast = useToaster();
+  const systematicStudyId = localStorage.getItem("systematicReviewId") ?? "";
+
+  useEffect(() => {
+    if (!systematicStudyId) return;
+
+    fetchCollaborators(systematicStudyId)
+      .then(setResearchers)
+      .catch(() => {
+        toast({
+          title: t("generalDefinition.input.researchers.toasts.loadError.title"),
+          description: t("generalDefinition.input.researchers.toasts.loadError.description"),
+          status: "error",
+        });
+      });
+  }, [systematicStudyId]);
 
   return (
     <>
       <Text mt={"30px"} fontWeight={500} fontSize={"large"}>{t("generalDefinition.input.researchers.label")}</Text>
-
       <VStack spacing={0} align="stretch" border="2px solid" borderColor="gray.300" borderRadius="md" bgColor="#ffffffff" px={2} py={2}>
-        <AddResearcher researchers={researchers} setResearchers={setResearchers}/>
-        <IncludedResearchers researchers={researchers} setResearchers={setResearchers}/>
+        <AddResearcher researchers={researchers} setResearchers={setResearchers} systematicStudyId={systematicStudyId}/>
+        <IncludedResearchers researchers={researchers} setResearchers={setResearchers} systematicStudyId={systematicStudyId}/>
       </VStack>
     </>
   );

--- a/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/services/searchCollaboratorCandidates.ts
+++ b/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/services/searchCollaboratorCandidates.ts
@@ -1,0 +1,23 @@
+import Axios from "../../../../../../../../infrastructure/http/axiosClient";
+
+export interface CollaboratorCandidate {
+  id: string;
+  username: string;
+  email: string;
+}
+
+interface Props {
+  systematicStudyId: string;
+  prefix: string;
+}
+
+export async function searchCollaboratorCandidates({
+  systematicStudyId,
+  prefix,
+}: Props): Promise<CollaboratorCandidate[]> {
+  const path = `systematic-study/${systematicStudyId}/search-researchers`;
+  const response = await Axios.get(path, { params: { prefix } });
+
+  const outer = response.data?.researchers;
+  return (outer?.researchers ?? outer ?? []) as CollaboratorCandidate[];
+}

--- a/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/services/useFetchCollaborators.ts
+++ b/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/services/useFetchCollaborators.ts
@@ -1,0 +1,38 @@
+import Axios from "../../../../../../../../infrastructure/http/axiosClient";
+
+export interface Researcher {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  status: "included" | "pending" | "expired";
+}
+
+export async function fetchCollaborators(
+  systematicStudyId: string
+): Promise<Researcher[]> {
+  const path = `systematic-study/${systematicStudyId}/collaborators`;
+  const response = await Axios.get(path);
+ 
+  const invited: Researcher[] = (response.data?.invited ?? [])
+    .filter((c: any) => c.status === "PENDENTE" || c.status === "EXPIRADO")
+    .map((c: any) => ({
+      id: c.id,
+      name: c.username,
+      email: c.email,
+      role: "reviewer",
+      status: c.status === "EXPIRADO" ? ("expired" as const) : ("pending" as const),
+    }));
+ 
+  const collaborators: Researcher[] = (response.data?.collaborators ?? []).map(
+    (c: any) => ({
+      id: c.id,
+      name: c.username,
+      email: c.email,
+      role: (c.role as string).toLowerCase(),
+      status: "included" as const,
+    })
+  );
+ 
+  return [...invited, ...collaborators];
+}

--- a/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/services/useInviteCollaborator.ts
+++ b/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/services/useInviteCollaborator.ts
@@ -1,0 +1,21 @@
+import Axios from "../../../../../../../../infrastructure/http/axiosClient";
+
+interface Props {
+  systematicStudyId: string;
+  usernameCollaborator: string;
+}
+
+export interface InviteCollaboratorResponse {
+  collaboratorUsername: string;
+  collaboratorEmail: string;
+  inviteStatus: string;
+}
+
+export async function inviteCollaborator({
+  systematicStudyId,
+  usernameCollaborator,
+}: Props): Promise<InviteCollaboratorResponse> {
+  const path = `systematic-study/${systematicStudyId}/invite-collaborator`;
+  const response = await Axios.post(path, { usernameCollaborator });
+  return response.data as InviteCollaboratorResponse;
+}

--- a/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/services/useRemoveCollaborator.ts
+++ b/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/services/useRemoveCollaborator.ts
@@ -1,0 +1,14 @@
+import Axios from "../../../../../../../../infrastructure/http/axiosClient";
+
+interface Props {
+  systematicStudyId: string;
+  researcherId: string;
+}
+
+export async function removeCollaborator({
+  systematicStudyId,
+  researcherId,
+}: Props): Promise<void> {
+  const path = `systematic-study/${systematicStudyId}/collaborator/${researcherId}`;
+  await Axios.delete(path);
+}

--- a/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/services/useUpdateResearcherRole.ts
+++ b/src/features/review/planning-protocol/pages/GeneralDefinition/subcomponents/ResearcherFilter/services/useUpdateResearcherRole.ts
@@ -1,0 +1,16 @@
+import Axios from "../../../../../../../../infrastructure/http/axiosClient";
+
+interface Props {
+  systematicStudyId: string;
+  researcherId: string;
+  role: string;
+}
+
+export async function updateResearcherRole({
+  systematicStudyId,
+  researcherId,
+  role,
+}: Props): Promise<void> {
+  const path = `systematic-study/${systematicStudyId}/collaborator`;
+  await Axios.put(path, { researcherId, role: role.toUpperCase() });
+}

--- a/src/features/user/my-reviews/services/useGetReviewCard.tsx
+++ b/src/features/user/my-reviews/services/useGetReviewCard.tsx
@@ -24,8 +24,7 @@ export default function useGetReviewCard() {
 
   const userId = user?.id ?? null;
 
-  const path =
-    !authLoading && userId ? `systematic-study/owner/${userId}` : null;
+  const path = !authLoading && userId ? "systematic-study" : null;
 
   const fetchAllCardReview = async () => {
     if (!path) return;

--- a/src/locales/en/landing/email-pages.json
+++ b/src/locales/en/landing/email-pages.json
@@ -8,5 +8,16 @@
       "successTitle": "Success!",
       "successDesc": "Account confirmed! You can login now"
     }
+  },
+  "joinReview": {
+    "loading": "Processing your invitation...",
+    "toast": {
+      "emptyTokenTitle": "Invalid token!",
+      "emptyTokenDesc": "Back to main page in 3 seconds..",
+      "successTitle": "Invitation accepted!",
+      "successDesc": "You are now part of the review. Redirecting...",
+      "errorTitle": "Failed to accept invitation",
+      "errorDesc": "The invitation may be expired or already used. Please try again."
+    }
   }
 }

--- a/src/locales/en/review/planning-protocol.json
+++ b/src/locales/en/review/planning-protocol.json
@@ -29,8 +29,10 @@
                 },
                 "role": {
                     "role": "Role",
-                    "admin": "admin",
+                    "viewer": "viewer",
                     "reviewer": "reviewer",
+                    "editor": "editor",
+                    "admin": "admin",
                     "owner": "owner"
                 },
                 "confirm": {
@@ -38,6 +40,31 @@
                     "body": "Are you sure you want to delete",
                     "cancel": "Cancel",
                     "delete": "Delete"
+                },
+                "toasts": {
+                    "loadError": {
+                        "title": "Failed to load researchers",
+                        "description": "Could not load the collaborators for this review."
+                    },
+                    "inviteSent": {
+                        "title": "Invite sent",
+                        "description": "Invite sent to"
+                    },
+                    "inviteError": {
+                        "title": "Failed to send invite",
+                        "description": "Could not send the invite. Please try again."
+                    },
+                    "roleUpdated": {
+                        "title": "Role updated successfully"
+                    },
+                    "roleUpdateError": {
+                        "title": "Failed to update role",
+                        "description": "Could not update the role. Please try again."
+                    },
+                    "removeError": {
+                        "title": "Failed to remove collaborator",
+                        "description": "Could not remove the collaborator. Please try again."
+                    }
                 }
             }
         },

--- a/src/locales/pt/landing/email-pages.json
+++ b/src/locales/pt/landing/email-pages.json
@@ -8,5 +8,16 @@
       "successTitle": "Sucesso!",
       "successDesc": "Conta confirmada! Você já pode fazer login"
     }
+  },
+  "joinReview": {
+    "loading": "Processando seu convite...",
+    "toast": {
+      "emptyTokenTitle": "Token inválido!",
+      "emptyTokenDesc": "Voltando para a página inicial em 3 segundos..",
+      "successTitle": "Convite aceito!",
+      "successDesc": "Você agora faz parte da revisão. Redirecionando...",
+      "errorTitle": "Erro ao aceitar convite",
+      "errorDesc": "O convite pode estar expirado ou já ter sido usado. Tente novamente."
+    }
   }
 }

--- a/src/locales/pt/review/planning-protocol.json
+++ b/src/locales/pt/review/planning-protocol.json
@@ -29,8 +29,10 @@
                 },
                 "role": {
                     "role": "Função",
-                    "admin": "administrador",
+                    "viewer": "visualizador",
                     "reviewer": "revisor",
+                    "editor": "editor",
+                    "admin": "administrador",
                     "owner": "dono"
                 },
                 "confirm": {
@@ -38,6 +40,31 @@
                     "body": "Tem certeza que quer remover",
                     "cancel": "Cancelar",
                     "delete": "Remover"
+                },
+                "toasts": {
+                    "loadError": {
+                        "title": "Erro ao carregar pesquisadores",
+                        "description": "Não foi possível carregar os colaboradores da revisão."
+                    },
+                    "inviteSent": {
+                        "title": "Convite enviado",
+                        "description": "Convite enviado para"
+                    },
+                    "inviteError": {
+                        "title": "Erro ao enviar convite",
+                        "description": "Não foi possível enviar o convite. Tente novamente."
+                    },
+                    "roleUpdated": {
+                        "title": "Função atualizada com sucesso"
+                    },
+                    "roleUpdateError": {
+                        "title": "Erro ao atualizar função",
+                        "description": "Não foi possível atualizar a função. Tente novamente."
+                    },
+                    "removeError": {
+                        "title": "Erro ao remover colaborador",
+                        "description": "Não foi possível remover o colaborador. Tente novamente."
+                    }
                 }
             }
         },

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -41,6 +41,9 @@ import Unauthorized from "@features/application/pages/UnauthorizedPage";
 import ServerError from "@features/application/pages/ServerErrorPage";
 import ConfirmAccount from "@features/auth/components/pages";
 
+// Collaboration
+import JoinReview from "@features/review/join-review/pages";
+
 const routesList: RouteObject[] = [
   {
     path: "/",
@@ -71,6 +74,10 @@ const routesList: RouteObject[] = [
     element: <ConfirmAccount />,
   },
   {
+    path: "/join-review",
+    element: <ProtectedRoute element={<JoinReview />} />,
+  },
+  {
     path: "/review/planning/protocol/general-definition",
     element: <ProtectedRoute element={<GeneralDefinition />} />,
   },
@@ -98,7 +105,7 @@ const routesList: RouteObject[] = [
   },
   {
     path: "/review/planning/protocol/risk-of-bias-assessment/:id",
-    element: <ProtectedRoute element={<RiskOfBiasAssessment/>} />,
+    element: <ProtectedRoute element={<RiskOfBiasAssessment />} />,
   },
   {
     path: "/review/planning/protocol/analysis-and-synthesis-of-results/:id",
@@ -133,9 +140,9 @@ const routesList: RouteObject[] = [
     element: <ProtectedRoute element={<Visualization />} />,
   },
   {
-      path: "/review/summarization/download",
-      element: <ProtectedRoute element={<Download />} />,
-    },
+    path: "/review/summarization/download",
+    element: <ProtectedRoute element={<Download />} />,
+  },
 ];
 
 export default function AppRoutes() {


### PR DESCRIPTION
## Descrição: Integração completa do componente de adição de colaboradores ao backend, incluindo o fluxo de convite.

### O que foi feito

- Criada pasta services/ dentro de ResearcherFilter/ com cinco services isolados: busca de colaboradores (useFetchCollaborators), busca de candidatos (searchCollaboratorCandidates), convite (useInviteCollaborator), atualização de role (useUpdateResearcherRole) e remoção (useRemoveCollaborator)
- ResearcherFilter/index.tsx substituído o mock pelo GET /systematic-study/{id}/collaborators, que retorna nome, e-mail e role reais dos colaboradores
- AddResearcher.tsx integrado com busca de candidatos via GET /search-researchers?prefix={prefix} e convite via POST /invite-collaborator
- IncludedResearchers.tsx integrado com atualização de role via PUT /collaborator e remoção real via DELETE /collaborator/{researcherId}
- Criada página JoinReview que processa o link do e-mail de convite (/#/join-review?token=...), chama POST /respond-invitation e redireciona para /home após o aceite
- Criado service respondInvitation seguindo o padrão Either já adotado no projeto
Adicionada rota /join-review no routes.tsx
- Corrigido useGetReviewCard para usar GET /systematic-study sem owner/{userId}, permitindo que revisões onde o usuário foi convidado apareçam na listagem após aceitar o convite